### PR TITLE
Fix preferences padding and dropdown styling

### DIFF
--- a/app/dashboard/preferences/page.tsx
+++ b/app/dashboard/preferences/page.tsx
@@ -113,10 +113,10 @@ export default function PartnerPreferencesPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-amber-50 to-yellow-50 pb-20">
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-amber-50 to-yellow-50">
       <MobileNav userProfile={profile} />
 
-      <main className="pt-20 px-4">
+      <main className="pt-24 pb-40 px-4 min-h-screen">
         <div className="max-w-2xl mx-auto">
           {/* Header */}
           <div className="flex items-center gap-3 mb-6">

--- a/components/dashboard/mobile-nav.tsx
+++ b/components/dashboard/mobile-nav.tsx
@@ -133,7 +133,7 @@ export default function MobileNav({ userProfile }: MobileNavProps) {
             {isProfileMenuOpen && (
               <>
                 <div className="fixed inset-0 z-30" onClick={() => setIsProfileMenuOpen(false)} />
-                <div className="absolute top-full right-0 mt-2 w-64 bg-white/95 backdrop-blur-md border border-orange-200 rounded-2xl shadow-2xl z-40 overflow-hidden animate-in slide-in-from-top-2 duration-200">
+                <div className="absolute top-full right-0 mt-2 w-64 bg-white backdrop-blur-md border border-orange-200 rounded-2xl shadow-2xl z-40 overflow-hidden animate-in slide-in-from-top-2 duration-200">
                   {/* User Info */}
                   <div className="p-4 bg-gradient-to-r from-orange-50 to-pink-50 border-b border-orange-100">
                     <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- avoid bottom nav overlap on partner preferences page
- make profile dropdown solid white

## Testing
- `pnpm install`
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_684f2bbb73388322a93f2e3d44f5b68c