### PR TITLE
Add spiritual and professional settings

### DIFF
--- a/scripts/add-account-status.sql
+++ b/scripts/add-account-status.sql
@@ -1,0 +1,24 @@
+-- Add account management columns to users table
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'users' AND column_name = 'account_status'
+    ) THEN
+        ALTER TABLE users
+            ADD COLUMN account_status TEXT DEFAULT 'active';
+        ALTER TABLE users
+            ADD CONSTRAINT users_account_status_check
+            CHECK (account_status IN ('active','deactivated','deleted'));
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'users' AND column_name = 'deactivated_at'
+    ) THEN
+        ALTER TABLE users ADD COLUMN deactivated_at TIMESTAMP WITH TIME ZONE;
+    END IF;
+END $$;
+
+-- Index for quick lookups by status
+CREATE INDEX IF NOT EXISTS idx_users_account_status ON users(account_status);


### PR DESCRIPTION
## Summary
- expand account settings form with education, profession, income and spiritual fields
- include actions to deactivate or delete account
- add SQL migration for account_status management

## Testing
- `pnpm install`
- `pnpm run build`
- `npx tsc -p tsconfig.json` *(fails: Argument type issues)*

------
https://chatgpt.com/codex/tasks/task_e_684f33ee3ff88322a5c00092439cac69