### PR TITLE
Update spiritual org options

### DIFF
--- a/app/dashboard/preferences/page.tsx
+++ b/app/dashboard/preferences/page.tsx
@@ -11,6 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { ArrowLeft, Save, Heart, Users, MapPin } from "lucide-react"
 import MobileNav from "@/components/dashboard/mobile-nav"
 import { toast, Toaster } from "sonner"
+import { SPIRITUAL_ORGS } from "@/lib/constants/spiritual-orgs"
 
 export default function PartnerPreferencesPage() {
   const [user, setUser] = useState<any>(null)
@@ -101,6 +102,21 @@ export default function PartnerPreferencesPage() {
       toast.error("Failed to update partner preferences. Please try again.")
     } finally {
       setSaving(false)
+    }
+  }
+
+  const handleMultiSelect = (value: string) => {
+    const current = preferences.preferred_spiritual_org || []
+    if (current.includes(value)) {
+      setPreferences({
+        ...preferences,
+        preferred_spiritual_org: current.filter((v) => v !== value),
+      })
+    } else {
+      setPreferences({
+        ...preferences,
+        preferred_spiritual_org: [...current, value],
+      })
     }
   }
 
@@ -279,9 +295,48 @@ export default function PartnerPreferencesPage() {
                       <SelectItem value="weekly">Weekly</SelectItem>
                       <SelectItem value="monthly">Monthly</SelectItem>
                       <SelectItem value="occasionally">Occasionally</SelectItem>
-                      <SelectItem value="festivals_only">Festivals Only</SelectItem>
-                    </SelectContent>
+                    <SelectItem value="festivals_only">Festivals Only</SelectItem>
+                  </SelectContent>
                   </Select>
+                </div>
+
+                <div>
+                  <Label>Preferred Spiritual Organizations</Label>
+                  <div className="flex flex-wrap gap-2 mt-2">
+                    {SPIRITUAL_ORGS.map((org) => (
+                      <button
+                        key={org}
+                        type="button"
+                        onClick={() => handleMultiSelect(org)}
+                        className={`px-3 py-1 text-sm rounded-full ${
+                          preferences.preferred_spiritual_org.includes(org)
+                            ? "bg-primary text-primary-foreground"
+                            : "bg-muted text-muted-foreground"
+                        }`}
+                      >
+                        {org}
+                      </button>
+                    ))}
+                  </div>
+                  {preferences.preferred_spiritual_org.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mt-2">
+                      {preferences.preferred_spiritual_org.map((org) => (
+                        <span
+                          key={org}
+                          className="inline-flex items-center bg-accent text-accent-foreground px-2 py-1 rounded-md text-xs"
+                        >
+                          {org}
+                          <button
+                            type="button"
+                            onClick={() => handleMultiSelect(org)}
+                            className="ml-1 text-muted-foreground hover:text-foreground"
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </CardContent>
             </Card>

--- a/components/onboarding/stages/petals-stage.tsx
+++ b/components/onboarding/stages/petals-stage.tsx
@@ -5,6 +5,7 @@ import { useState } from "react"
 import { Loader2, X } from "lucide-react"
 import type { OnboardingData } from "@/lib/types/onboarding"
 import { VALID_VALUES } from "@/lib/types/onboarding"
+import { SPIRITUAL_ORGS } from "@/lib/constants/spiritual-orgs"
 
 interface PetalsStageProps {
   formData: OnboardingData
@@ -90,17 +91,7 @@ export default function PetalsStage({ formData, onChange, onNext, isLoading, err
     onNext(dataToSave) // Trigger save and next stage
   }
 
-  const spiritualOrgs = [
-    "ISKCON",
-    "Ramakrishna Mission",
-    "Art of Living",
-    "Brahma Kumaris",
-    "Chinmaya Mission",
-    "Swaminarayan",
-    "Sathya Sai Organization",
-    "Divine Life Society",
-    "Other",
-  ]
+  const spiritualOrgs = [...SPIRITUAL_ORGS]
 
   const dailyPractices = [
     "Meditation",

--- a/lib/constants/spiritual-orgs.ts
+++ b/lib/constants/spiritual-orgs.ts
@@ -1,0 +1,19 @@
+export const SPIRITUAL_ORGS = [
+  "Isha Foundation",
+  "Vipassana/Dhamma",
+  "ISKCON/Hare Krishna",
+  "Ramakrishna Mission",
+  "Art of Living",
+  "Brahma Kumaris",
+  "Chinmaya Mission",
+  "Swaminarayan",
+  "Sathya Sai Organization",
+  "Divine Life Society",
+  "Osho International",
+  "Self-Realization Fellowship/YSS",
+  "Sri Aurobindo Ashram",
+  "Mata Amritanandamayi Math",
+  "Ananda Marga",
+  "Other (please specify)",
+] as const;
+export type SpiritualOrg = (typeof SPIRITUAL_ORGS)[number];


### PR DESCRIPTION
## Summary
- centralize spiritual organization names
- use new list in onboarding petals stage
- expose spiritual org preference selector

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f33eaed5083228726fd2a0ebb491d