### PR TITLE
Add verification status support

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -193,7 +193,7 @@ export default function DashboardPage() {
   }
 
   const profileCompleteness = calculateProfileCompleteness()
-  const isVerified = profile?.email_verified && profile?.mobile_verified // Add your verification logic here
+  const isVerified = profile?.verification_status === 'verified'
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-orange-50 via-amber-50 to-yellow-50">

--- a/components/auth-dialog.tsx
+++ b/components/auth-dialog.tsx
@@ -327,10 +327,11 @@ export default function AuthDialog({ isOpen, onClose, defaultMode }: AuthDialogP
               first_name: mobileAuthData.firstName,
               last_name: mobileAuthData.lastName,
               full_name: `${mobileAuthData.firstName} ${mobileAuthData.lastName}`,
-              mobile_number: mobileAuthData.mobileNumber,
-              email_verified: false,
-              mobile_verified: true,
-              onboarding_completed: false,
+            mobile_number: mobileAuthData.mobileNumber,
+            email_verified: false,
+            mobile_verified: true,
+            verification_status: 'pending',
+            onboarding_completed: false,
               created_at: new Date().toISOString(),
               updated_at: new Date().toISOString(),
             }
@@ -467,6 +468,7 @@ export default function AuthDialog({ isOpen, onClose, defaultMode }: AuthDialogP
             full_name: `${signupData.firstName} ${signupData.lastName}`,
             mobile_number: signupData.mobileNumber,
             email_verified: !!authData.user.email_confirmed_at, // Set based on auth status
+            verification_status: 'pending',
             onboarding_completed: false,
             created_at: new Date().toISOString(),
             updated_at: new Date().toISOString(),

--- a/components/dashboard/mobile-nav.tsx
+++ b/components/dashboard/mobile-nav.tsx
@@ -151,7 +151,13 @@ export default function MobileNav({ userProfile }: MobileNavProps) {
                           {userProfile?.first_name} {userProfile?.last_name}
                         </p>
                         <p className="text-sm text-gray-600">
-                          {userProfile?.fast_track_verification ? "Fast Track Verification" : "Profile Under Review"}
+                          {userProfile?.verification_status === 'verified'
+                            ? 'Verified'
+                            : userProfile?.verification_status === 'rejected'
+                            ? 'Verification Rejected'
+                            : userProfile?.fast_track_verification
+                            ? 'Fast Track Verification'
+                            : 'Profile Under Review'}
                         </p>
                       </div>
                     </div>

--- a/components/signup-section.tsx
+++ b/components/signup-section.tsx
@@ -144,6 +144,7 @@ export default function SignupSection() {
             full_name: `${formData.firstName} ${formData.lastName}`,
             mobile_number: formData.mobileNumber,
             email_verified: !!authData.user.email_confirmed_at,
+            verification_status: 'pending',
             onboarding_completed: false,
             created_at: new Date().toISOString(),
             updated_at: new Date().toISOString(),

--- a/lib/types/onboarding.ts
+++ b/lib/types/onboarding.ts
@@ -41,6 +41,7 @@ export interface OnboardingProfile extends OnboardingData {
   first_name?: string
   last_name?: string
   mobile_number?: string
+  verification_status?: 'pending' | 'verified' | 'rejected'
   onboarding_completed?: boolean
   updated_at?: string
 }

--- a/scripts/add-verification-status.sql
+++ b/scripts/add-verification-status.sql
@@ -1,0 +1,18 @@
+-- Add verification_status column to users table
+ALTER TABLE users ADD COLUMN IF NOT EXISTS verification_status TEXT DEFAULT 'pending';
+
+-- Ensure allowed values
+ALTER TABLE users
+  ADD CONSTRAINT IF NOT EXISTS users_verification_status_check
+  CHECK (verification_status IN ('pending','verified','rejected'));
+
+-- Auto-mark existing phone-verified users
+UPDATE users
+SET verification_status = 'verified'
+WHERE mobile_verified = TRUE;
+
+-- Create index for faster lookups
+CREATE INDEX IF NOT EXISTS idx_users_verification_status ON users(verification_status);
+
+-- Add comment for documentation
+COMMENT ON COLUMN users.verification_status IS 'Account review status: pending, verified, or rejected';

--- a/scripts/create-users-table.sql
+++ b/scripts/create-users-table.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS users (
   partner_expectations TEXT,
   user_photos TEXT[],
   email_verified BOOLEAN DEFAULT FALSE,
+  verification_status TEXT DEFAULT 'pending' CHECK (verification_status IN ('pending','verified','rejected')),
   onboarding_completed BOOLEAN DEFAULT FALSE,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
@@ -105,10 +106,12 @@ ALTER TABLE users ADD CONSTRAINT users_mobile_number_check
 -- Add indexes for performance
 CREATE INDEX IF NOT EXISTS idx_users_mobile_number ON users(mobile_number);
 CREATE INDEX IF NOT EXISTS idx_users_email_verified ON users(email_verified);
+CREATE INDEX IF NOT EXISTS idx_users_verification_status ON users(verification_status);
 CREATE INDEX IF NOT EXISTS idx_users_onboarding_completed ON users(onboarding_completed);
 
 -- Add comments explaining the fields
 COMMENT ON COLUMN users.email_verified IS 'Whether the user has verified their email address during onboarding';
+COMMENT ON COLUMN users.verification_status IS 'Account review status: pending, verified, or rejected';
 COMMENT ON COLUMN users.mobile_number IS 'User mobile/phone number with country code (optional)';
 COMMENT ON CONSTRAINT users_gender_check ON users IS 'Ensures gender is either NULL or one of: Male, Female, Other';
 COMMENT ON CONSTRAINT users_diet_check ON users IS 'Ensures diet is either NULL or one of: Vegetarian, Vegan, Eggetarian, Non-Vegetarian';

--- a/scripts/verification-status-trigger.sql
+++ b/scripts/verification-status-trigger.sql
@@ -1,0 +1,17 @@
+-- Automatically update verification_status when the phone is verified
+CREATE OR REPLACE FUNCTION set_verification_status()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.mobile_verified = TRUE THEN
+    NEW.verification_status := 'verified';
+  ELSIF NEW.verification_status IS NULL THEN
+    NEW.verification_status := 'pending';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_set_verification_status ON users;
+CREATE TRIGGER trigger_set_verification_status
+  BEFORE INSERT OR UPDATE OF mobile_verified ON users
+  FOR EACH ROW EXECUTE FUNCTION set_verification_status();


### PR DESCRIPTION
## Summary
- support `verification_status` on users table
- seed verification status for new signups
- show account review state in mobile nav
- gate dashboard features on `verification_status`
- add SQL helpers for verification status automation
- use phone check only for automatic verification

## Testing
- `pnpm install`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_684f340673dc83228692540398debb9f