### PR TITLE
Fix verification automation logic

### DIFF
--- a/scripts/add-verification-status.sql
+++ b/scripts/add-verification-status.sql
@@ -6,10 +6,9 @@ ALTER TABLE users
   ADD CONSTRAINT IF NOT EXISTS users_verification_status_check
   CHECK (verification_status IN ('pending','verified','rejected'));
 
--- Auto-mark existing phone-verified users
-UPDATE users
-SET verification_status = 'verified'
-WHERE mobile_verified = TRUE;
+-- Verification is determined manually from the admin panel. Phone verification
+-- does not automatically mark a user as verified, so we do not update existing
+-- records here.
 
 -- Create index for faster lookups
 CREATE INDEX IF NOT EXISTS idx_users_verification_status ON users(verification_status);

--- a/scripts/verification-status-trigger.sql
+++ b/scripts/verification-status-trigger.sql
@@ -1,10 +1,8 @@
--- Automatically update verification_status when the phone is verified
+-- Ensure verification_status is set to 'pending' if not provided
 CREATE OR REPLACE FUNCTION set_verification_status()
 RETURNS TRIGGER AS $$
 BEGIN
-  IF NEW.mobile_verified = TRUE THEN
-    NEW.verification_status := 'verified';
-  ELSIF NEW.verification_status IS NULL THEN
+  IF NEW.verification_status IS NULL THEN
     NEW.verification_status := 'pending';
   END IF;
   RETURN NEW;
@@ -13,5 +11,5 @@ $$ LANGUAGE plpgsql;
 
 DROP TRIGGER IF EXISTS trigger_set_verification_status ON users;
 CREATE TRIGGER trigger_set_verification_status
-  BEFORE INSERT OR UPDATE OF mobile_verified ON users
+  BEFORE INSERT OR UPDATE ON users
   FOR EACH ROW EXECUTE FUNCTION set_verification_status();


### PR DESCRIPTION
## Summary
- stop auto-marking phone-verified users as `verified`
- only ensure `verification_status` defaults to `pending`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4042a49c8322b67ad098187a54d6