### PR TITLE
Add state-city data and improve onboarding UI

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -200,15 +200,10 @@ export default function DashboardPage() {
       <MobileNav userProfile={profile} />
 
       {/* Main Content */}
-      <main className="pt-24 pb-32 min-h-screen flex flex-col">
+      <main className="pt-16 pb-32 min-h-screen flex flex-col">
         {isVerified ? (
           // Verified User - Swipe Interface
-          <div className="flex-1 flex flex-col">
-            <div className="text-center px-4 py-4">
-              <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-2">Discover Your Match 💫</h1>
-              <p className="text-gray-600">Swipe right to like, left to pass</p>
-            </div>
-
+          <div className="flex-1 flex flex-col mt-4">
             <SwipeStack profiles={profiles} onSwipe={handleSwipe} />
           </div>
         ) : (

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -8,6 +8,9 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { useStates, useCities } from "@/lib/hooks/useLocations"
+import { SPIRITUAL_ORGS } from "@/lib/constants/spiritual-orgs"
+import { DAILY_PRACTICES } from "@/lib/constants/daily-practices"
 import {
   ArrowLeft,
   MapPin,
@@ -55,6 +58,10 @@ export default function AccountSettingsPage() {
   const [processingDeactivate, setProcessingDeactivate] = useState(false)
   const [processingDelete, setProcessingDelete] = useState(false)
 
+  const statesList = useStates()
+  const selectedState = statesList.find((s) => s.name === formData.state)
+  const citiesList = useCities(selectedState?.state_code || null)
+
   const [formData, setFormData] = useState({
     first_name: "",
     last_name: "",
@@ -64,6 +71,7 @@ export default function AccountSettingsPage() {
     state: "",
     country: "",
     birthdate: "",
+    height: "",
     gender: "",
     education: "",
     profession: "",
@@ -72,6 +80,8 @@ export default function AccountSettingsPage() {
     temple_visit_freq: "",
     vanaprastha_interest: "",
     artha_vs_moksha: "",
+    spiritual_org: [],
+    daily_practices: [],
   })
 
   const educationLevels = [
@@ -137,6 +147,7 @@ export default function AccountSettingsPage() {
           state: profileData.state || "",
           country: profileData.country || "",
           birthdate: profileData.birthdate || "",
+          height: profileData.height || "",
           gender: profileData.gender || "",
           education: profileData.education || "",
           profession: profileData.profession || "",
@@ -145,6 +156,8 @@ export default function AccountSettingsPage() {
           temple_visit_freq: profileData.temple_visit_freq || "",
           vanaprastha_interest: profileData.vanaprastha_interest || "",
           artha_vs_moksha: profileData.artha_vs_moksha || "",
+          spiritual_org: profileData.spiritual_org || [],
+          daily_practices: profileData.daily_practices || [],
         })
         setNewMobileNumber(profileData.mobile_number || "")
         setLoading(false)
@@ -381,7 +394,7 @@ export default function AccountSettingsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-amber-50 to-yellow-50 pb-20">
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-amber-50 to-yellow-50 pb-40">
       <MobileNav userProfile={profile} />
 
       <main className="pt-20 px-4">
@@ -453,6 +466,15 @@ export default function AccountSettingsPage() {
                     type="date"
                     value={formData.birthdate}
                     onChange={(e) => setFormData({ ...formData, birthdate: e.target.value })}
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="height">Height (cm)</Label>
+                  <Input
+                    id="height"
+                    type="number"
+                    value={formData.height}
+                    onChange={(e) => setFormData({ ...formData, height: e.target.value })}
                   />
                 </div>
               </CardContent>
@@ -606,8 +628,14 @@ export default function AccountSettingsPage() {
                     id="city"
                     value={formData.city}
                     onChange={(e) => setFormData({ ...formData, city: e.target.value })}
-                    placeholder="Enter city"
+                    placeholder="Select city"
+                    list="city-list"
                   />
+                  <datalist id="city-list">
+                    {citiesList.map((c) => (
+                      <option key={c.id} value={c.name} />
+                    ))}
+                  </datalist>
                 </div>
 
                 <div className="grid grid-cols-2 gap-4">
@@ -617,8 +645,14 @@ export default function AccountSettingsPage() {
                       id="state"
                       value={formData.state}
                       onChange={(e) => setFormData({ ...formData, state: e.target.value })}
-                      placeholder="Enter state"
+                      placeholder="Select state"
+                      list="state-list"
                     />
+                    <datalist id="state-list">
+                      {statesList.map((s) => (
+                        <option key={s.id} value={s.name} />
+                      ))}
+                    </datalist>
                   </div>
                   <div>
                     <Label htmlFor="country">Country</Label>
@@ -703,6 +737,48 @@ export default function AccountSettingsPage() {
                 <CardDescription>Share your spiritual preferences</CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
+                <div>
+                  <Label>Spiritual Organizations</Label>
+                  <div className="flex flex-wrap gap-2">
+                    {SPIRITUAL_ORGS.map((org) => (
+                      <button
+                        key={org}
+                        type="button"
+                        onClick={() => {
+                          const arr = formData.spiritual_org.includes(org)
+                            ? formData.spiritual_org.filter((o: string) => o !== org)
+                            : [...formData.spiritual_org, org]
+                          setFormData({ ...formData, spiritual_org: arr })
+                        }}
+                        className={`px-3 py-1 text-sm rounded-full ${formData.spiritual_org.includes(org) ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'}`}
+                      >
+                        {org}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <Label>Daily Practices</Label>
+                  <div className="flex flex-wrap gap-2">
+                    {DAILY_PRACTICES.map((p) => (
+                      <button
+                        key={p}
+                        type="button"
+                        onClick={() => {
+                          const arr = formData.daily_practices.includes(p)
+                            ? formData.daily_practices.filter((d: string) => d !== p)
+                            : [...formData.daily_practices, p]
+                          setFormData({ ...formData, daily_practices: arr })
+                        }}
+                        className={`px-3 py-1 text-sm rounded-full ${formData.daily_practices.includes(p) ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'}`}
+                      >
+                        {p}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
                 <div>
                   <Label htmlFor="diet">Diet</Label>
                   <Select

--- a/components/dashboard/profile-image-uploader.tsx
+++ b/components/dashboard/profile-image-uploader.tsx
@@ -72,9 +72,9 @@ export default function ProfileImageUploader({ userId, currentImages, onImagesUp
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
     if (file) {
-      if (file.size > 2 * 1024 * 1024) {
-        // 2MB limit for base64 storage
-        toast.error("Image size should be less than 2MB")
+      if (file.size > 10 * 1024 * 1024) {
+        // 10MB limit
+        toast.error("Image size should be less than 10MB")
         return
       }
 
@@ -134,7 +134,7 @@ export default function ProfileImageUploader({ userId, currentImages, onImagesUp
       <input ref={fileInputRef} type="file" accept="image/*" onChange={handleFileSelect} className="hidden" />
 
       <p className="text-xs text-gray-500 text-center">
-        Add up to 6 photos. First photo will be your main profile picture. Max 2MB per image.
+        Add up to 6 photos. First photo will be your main profile picture. Max 10MB per image.
       </p>
     </div>
   )

--- a/components/dashboard/swipe-card.tsx
+++ b/components/dashboard/swipe-card.tsx
@@ -22,10 +22,7 @@ export default function SwipeCard({ profile, onSwipe, isTop, index }: SwipeCardP
   const rotateRaw = useTransform(x, [-300, 300], [-30, 30])
   const opacity = useTransform(x, [-300, -150, 0, 150, 300], [0, 1, 1, 1, 0])
 
-  const isSwiping = useMotionValue(false)
-  const rotate = useTransform(() => {
-    return isSwiping.get() ? rotateRaw.get() : 0
-  })
+  const rotate = rotateRaw
 
   const calculateAge = (birthdate: string) => {
     if (!birthdate) return "N/A"
@@ -118,12 +115,7 @@ export default function SwipeCard({ profile, onSwipe, isTop, index }: SwipeCardP
           opacity,
           zIndex: isTop ? 20 : 10 - index,
         }}
-        drag={!isExpanded}
-        dragConstraints={{ left: 0, right: 0, top: 0, bottom: 0 }}
-        dragElastic={0.2}
-        onDragStart={() => isSwiping.set(true)}
-        onDragEnd={handleDragEnd}
-        onDrag={() => isSwiping.set(true)}
+        drag={false}
         whileTap={{ scale: isExpanded ? 1 : 0.95 }}
         layout
       >

--- a/components/onboarding/onboarding-container.tsx
+++ b/components/onboarding/onboarding-container.tsx
@@ -51,6 +51,7 @@ export default function OnboardingContainer({ user, profile, setProfile }: Onboa
     mobile_number: null, // Add this line
     gender: null,
     birthdate: null,
+    height: null,
     city: null,
     state: null,
     country: "India", // Default to India
@@ -78,6 +79,7 @@ export default function OnboardingContainer({ user, profile, setProfile }: Onboa
         mobile_number: profile.mobile_number || null, // Add this line
         gender: profile.gender || null,
         birthdate: profile.birthdate || null,
+        height: profile.height || null,
         city: profile.city || null,
         state: profile.state || null,
         country: profile.country || "India", // Default to India if not set
@@ -100,7 +102,7 @@ export default function OnboardingContainer({ user, profile, setProfile }: Onboa
       // First stage is now mobile verification
       if (!user?.phone_confirmed_at && !profile.mobile_verified) {
         setStage(1)
-      } else if (!profile.gender || !profile.birthdate) {
+      } else if (!profile.gender || !profile.birthdate || !profile.height) {
         setStage(2)
       } else if (!profile.education || !profile.profession) {
         setStage(3)
@@ -204,7 +206,7 @@ export default function OnboardingContainer({ user, profile, setProfile }: Onboa
         if (!stageData.gender) {
           throw new Error("Please select your gender before proceeding.")
         }
-        if (!stageData.birthdate || !stageData.city || !stageData.state || !stageData.country) {
+        if (!stageData.birthdate || !stageData.height || !stageData.city || !stageData.state || !stageData.country) {
           throw new Error("Please fill in all required fields before proceeding.")
         }
         break

--- a/components/onboarding/stages/petals-stage.tsx
+++ b/components/onboarding/stages/petals-stage.tsx
@@ -6,6 +6,7 @@ import { Loader2, X } from "lucide-react"
 import type { OnboardingData } from "@/lib/types/onboarding"
 import { VALID_VALUES } from "@/lib/types/onboarding"
 import { SPIRITUAL_ORGS } from "@/lib/constants/spiritual-orgs"
+import { DAILY_PRACTICES } from "@/lib/constants/daily-practices"
 
 interface PetalsStageProps {
   formData: OnboardingData
@@ -93,16 +94,7 @@ export default function PetalsStage({ formData, onChange, onNext, isLoading, err
 
   const spiritualOrgs = [...SPIRITUAL_ORGS]
 
-  const dailyPractices = [
-    "Meditation",
-    "Yoga",
-    "Chanting",
-    "Prayer",
-    "Scriptural Study",
-    "Seva/Service",
-    "Fasting",
-    "Other",
-  ]
+  const dailyPractices = [...DAILY_PRACTICES]
 
   const dietOptions = VALID_VALUES.diet.filter((d) => d !== null)
   const templeFreqOptions = VALID_VALUES.temple_visit_freq.filter((t) => t !== null)

--- a/components/onboarding/stages/stem-stage.tsx
+++ b/components/onboarding/stages/stem-stage.tsx
@@ -5,6 +5,8 @@ import { useState } from "react"
 import { Loader2 } from "lucide-react"
 import type { OnboardingData } from "@/lib/types/onboarding"
 import { VALID_VALUES } from "@/lib/types/onboarding"
+import { useStates, useCities } from "@/lib/hooks/useLocations"
+import { MOTHER_TONGUES } from "@/lib/constants/mother-tongues"
 
 interface StemStageProps {
   formData: OnboardingData
@@ -19,6 +21,7 @@ export default function StemStage({ formData, onChange, onNext, isLoading, error
   const {
     gender = null,
     birthdate = null,
+    height = null,
     city = null,
     state = null,
     country = "India", // Default to India
@@ -26,6 +29,10 @@ export default function StemStage({ formData, onChange, onNext, isLoading, error
   } = formData
 
   const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const statesList = useStates()
+  const selectedState = statesList.find((s) => s.name === state)
+  const citiesList = useCities(selectedState?.state_code || null)
 
   const validGenderOptions = VALID_VALUES.gender.filter((g) => g !== null) as Array<"Male" | "Female" | "Other">
 
@@ -67,6 +74,10 @@ export default function StemStage({ formData, onChange, onNext, isLoading, error
       }
     }
 
+    if (!height) {
+      newErrors.height = "Please enter your height"
+    }
+
     if (!city?.trim()) {
       newErrors.city = "Please enter your city"
     }
@@ -93,6 +104,7 @@ export default function StemStage({ formData, onChange, onNext, isLoading, error
       const dataToSave: Partial<OnboardingData> = {
         gender,
         birthdate,
+        height,
         city,
         state,
         country,
@@ -106,6 +118,7 @@ export default function StemStage({ formData, onChange, onNext, isLoading, error
     const dataToSave: Partial<OnboardingData> = {
       gender: null,
       birthdate: null,
+      height: null,
       city: null,
       state: null,
       country: "India",
@@ -172,6 +185,25 @@ export default function StemStage({ formData, onChange, onNext, isLoading, error
           {errors.birthdate && <p className="text-red-500 text-sm">{errors.birthdate}</p>}
         </div>
 
+        {/* Height */}
+        <div className="space-y-2">
+          <label htmlFor="height" className="block text-sm font-semibold text-gray-700">
+            Height (cm) *
+          </label>
+          <input
+            type="number"
+            id="height"
+            name="height"
+            value={height || ""}
+            onChange={handleChange}
+            placeholder="Enter your height"
+            className={`w-full px-4 py-3 border-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-colors ${
+              errors.height ? "border-red-300" : "border-gray-200"
+            }`}
+          />
+          {errors.height && <p className="text-red-500 text-sm">{errors.height}</p>}
+        </div>
+
         {/* City */}
         <div className="space-y-2">
           <label htmlFor="city" className="block text-sm font-semibold text-gray-700">
@@ -183,11 +215,17 @@ export default function StemStage({ formData, onChange, onNext, isLoading, error
             name="city"
             value={city || ""}
             onChange={handleChange}
-            placeholder="Enter your city"
+            placeholder="Select your city"
+            list="city-list"
             className={`w-full px-4 py-3 border-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-colors ${
               errors.city ? "border-red-300" : "border-gray-200"
             }`}
           />
+          <datalist id="city-list">
+            {citiesList.map((c) => (
+              <option key={c.id} value={c.name} />
+            ))}
+          </datalist>
           {errors.city && <p className="text-red-500 text-sm">{errors.city}</p>}
         </div>
 
@@ -202,11 +240,17 @@ export default function StemStage({ formData, onChange, onNext, isLoading, error
             name="state"
             value={state || ""}
             onChange={handleChange}
-            placeholder="Enter your state or province"
+            placeholder="Select your state"
+            list="state-list"
             className={`w-full px-4 py-3 border-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-colors ${
               errors.state ? "border-red-300" : "border-gray-200"
             }`}
           />
+          <datalist id="state-list">
+            {statesList.map((s) => (
+              <option key={s.id} value={s.name} />
+            ))}
+          </datalist>
           {errors.state && <p className="text-red-500 text-sm">{errors.state}</p>}
         </div>
 
@@ -240,11 +284,17 @@ export default function StemStage({ formData, onChange, onNext, isLoading, error
             name="mother_tongue"
             value={mother_tongue || ""}
             onChange={handleChange}
-            placeholder="Enter your mother tongue"
+            placeholder="Select mother tongue"
+            list="mother-tongue-list"
             className={`w-full px-4 py-3 border-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-colors ${
               errors.mother_tongue ? "border-red-300" : "border-gray-200"
             }`}
           />
+          <datalist id="mother-tongue-list">
+            {MOTHER_TONGUES.map((lang) => (
+              <option key={lang} value={lang} />
+            ))}
+          </datalist>
           {errors.mother_tongue && <p className="text-red-500 text-sm">{errors.mother_tongue}</p>}
         </div>
 

--- a/lib/constants/daily-practices.ts
+++ b/lib/constants/daily-practices.ts
@@ -1,0 +1,11 @@
+export const DAILY_PRACTICES = [
+  'Meditation',
+  'Yoga',
+  'Chanting',
+  'Prayer',
+  'Scriptural Study',
+  'Seva/Service',
+  'Fasting',
+  'Other'
+] as const
+export type DailyPractice = (typeof DAILY_PRACTICES)[number]

--- a/lib/constants/mother-tongues.ts
+++ b/lib/constants/mother-tongues.ts
@@ -1,0 +1,4 @@
+export const MOTHER_TONGUES = [
+  'Assamese','Bengali','Bodo','Dogri','Gujarati','Hindi','Kannada','Kashmiri','Konkani','Maithili','Malayalam','Manipuri','Marathi','Nepali','Odia','Punjabi','Sanskrit','Santali','Sindhi','Tamil','Telugu','Urdu'
+] as const
+export type MotherTongue = (typeof MOTHER_TONGUES)[number]

--- a/lib/data/india_cities.json
+++ b/lib/data/india_cities.json
@@ -1,0 +1,21032 @@
+[
+  {
+    "id": 57837,
+    "name": "Bamboo Flat",
+    "state_code": "AN"
+  },
+  {
+    "id": 133213,
+    "name": "Nicobar",
+    "state_code": "AN"
+  },
+  {
+    "id": 133482,
+    "name": "Port Blair",
+    "state_code": "AN"
+  },
+  {
+    "id": 134006,
+    "name": "South Andaman",
+    "state_code": "AN"
+  },
+  {
+    "id": 57593,
+    "name": "Addanki",
+    "state_code": "AP"
+  },
+  {
+    "id": 134452,
+    "name": "Adoni",
+    "state_code": "AP"
+  },
+  {
+    "id": 57620,
+    "name": "Akasahebpet",
+    "state_code": "AP"
+  },
+  {
+    "id": 57623,
+    "name": "Akividu",
+    "state_code": "AP"
+  },
+  {
+    "id": 57624,
+    "name": "Akkarampalle",
+    "state_code": "AP"
+  },
+  {
+    "id": 57658,
+    "name": "Amalapuram",
+    "state_code": "AP"
+  },
+  {
+    "id": 57690,
+    "name": "Amudalavalasa",
+    "state_code": "AP"
+  },
+  {
+    "id": 57693,
+    "name": "Anakapalle",
+    "state_code": "AP"
+  },
+  {
+    "id": 57698,
+    "name": "Anantapur",
+    "state_code": "AP"
+  },
+  {
+    "id": 57758,
+    "name": "Atmakur",
+    "state_code": "AP"
+  },
+  {
+    "id": 57761,
+    "name": "Attili",
+    "state_code": "AP"
+  },
+  {
+    "id": 57771,
+    "name": "Avanigadda",
+    "state_code": "AP"
+  },
+  {
+    "id": 57794,
+    "name": "Badvel",
+    "state_code": "AP"
+  },
+  {
+    "id": 57849,
+    "name": "Banganapalle",
+    "state_code": "AP"
+  },
+  {
+    "id": 58137,
+    "name": "Bapatla",
+    "state_code": "AP"
+  },
+  {
+    "id": 57939,
+    "name": "Betamcherla",
+    "state_code": "AP"
+  },
+  {
+    "id": 57971,
+    "name": "Bhattiprolu",
+    "state_code": "AP"
+  },
+  {
+    "id": 58021,
+    "name": "Bhimavaram",
+    "state_code": "AP"
+  },
+  {
+    "id": 58022,
+    "name": "Bhimunipatnam",
+    "state_code": "AP"
+  },
+  {
+    "id": 58070,
+    "name": "Bobbili",
+    "state_code": "AP"
+  },
+  {
+    "id": 58179,
+    "name": "Challapalle",
+    "state_code": "AP"
+  },
+  {
+    "id": 131514,
+    "name": "Chemmumiahpet",
+    "state_code": "AP"
+  },
+  {
+    "id": 131556,
+    "name": "Chilakalurupet",
+    "state_code": "AP"
+  },
+  {
+    "id": 131563,
+    "name": "Chinnachowk",
+    "state_code": "AP"
+  },
+  {
+    "id": 131611,
+    "name": "Chipurupalle",
+    "state_code": "AP"
+  },
+  {
+    "id": 131612,
+    "name": "Chirala",
+    "state_code": "AP"
+  },
+  {
+    "id": 131575,
+    "name": "Chittoor",
+    "state_code": "AP"
+  },
+  {
+    "id": 131577,
+    "name": "Chodavaram",
+    "state_code": "AP"
+  },
+  {
+    "id": 131627,
+    "name": "Cuddapah",
+    "state_code": "AP"
+  },
+  {
+    "id": 131628,
+    "name": "Cumbum",
+    "state_code": "AP"
+  },
+  {
+    "id": 131658,
+    "name": "Darsi",
+    "state_code": "AP"
+  },
+  {
+    "id": 131727,
+    "name": "Dharmavaram",
+    "state_code": "AP"
+  },
+  {
+    "id": 131740,
+    "name": "Dhone",
+    "state_code": "AP"
+  },
+  {
+    "id": 131769,
+    "name": "Diguvametta",
+    "state_code": "AP"
+  },
+  {
+    "id": 131823,
+    "name": "East Godavari",
+    "state_code": "AP"
+  },
+  {
+    "id": 131830,
+    "name": "Elamanchili",
+    "state_code": "AP"
+  },
+  {
+    "id": 131832,
+    "name": "Ellore",
+    "state_code": "AP"
+  },
+  {
+    "id": 131836,
+    "name": "Emmiganur",
+    "state_code": "AP"
+  },
+  {
+    "id": 131842,
+    "name": "Erraguntla",
+    "state_code": "AP"
+  },
+  {
+    "id": 131846,
+    "name": "Etikoppaka",
+    "state_code": "AP"
+  },
+  {
+    "id": 131895,
+    "name": "Gajuwaka",
+    "state_code": "AP"
+  },
+  {
+    "id": 131906,
+    "name": "Ganguvada",
+    "state_code": "AP"
+  },
+  {
+    "id": 131915,
+    "name": "Gannavaram",
+    "state_code": "AP"
+  },
+  {
+    "id": 131955,
+    "name": "Giddalur",
+    "state_code": "AP"
+  },
+  {
+    "id": 131972,
+    "name": "Gokavaram",
+    "state_code": "AP"
+  },
+  {
+    "id": 131993,
+    "name": "Gorantla",
+    "state_code": "AP"
+  },
+  {
+    "id": 132001,
+    "name": "GovindapuramChilakaluripetGuntur",
+    "state_code": "AP"
+  },
+  {
+    "id": 132010,
+    "name": "Gudivada",
+    "state_code": "AP"
+  },
+  {
+    "id": 132012,
+    "name": "Gudlavalleru",
+    "state_code": "AP"
+  },
+  {
+    "id": 132051,
+    "name": "Gudur",
+    "state_code": "AP"
+  },
+  {
+    "id": 132027,
+    "name": "Guntakal Junction",
+    "state_code": "AP"
+  },
+  {
+    "id": 132028,
+    "name": "Guntur",
+    "state_code": "AP"
+  },
+  {
+    "id": 132099,
+    "name": "Hindupur",
+    "state_code": "AP"
+  },
+  {
+    "id": 132151,
+    "name": "Ichchapuram",
+    "state_code": "AP"
+  },
+  {
+    "id": 132189,
+    "name": "Jaggayyapeta",
+    "state_code": "AP"
+  },
+  {
+    "id": 132228,
+    "name": "Jammalamadugu",
+    "state_code": "AP"
+  },
+  {
+    "id": 132328,
+    "name": "Kadiri",
+    "state_code": "AP"
+  },
+  {
+    "id": 132332,
+    "name": "Kaikalur",
+    "state_code": "AP"
+  },
+  {
+    "id": 132678,
+    "name": "Kakinada",
+    "state_code": "AP"
+  },
+  {
+    "id": 132358,
+    "name": "Kalyandurg",
+    "state_code": "AP"
+  },
+  {
+    "id": 132691,
+    "name": "Kamalapuram",
+    "state_code": "AP"
+  },
+  {
+    "id": 132372,
+    "name": "Kandukur",
+    "state_code": "AP"
+  },
+  {
+    "id": 132374,
+    "name": "Kanigiri",
+    "state_code": "AP"
+  },
+  {
+    "id": 132376,
+    "name": "Kankipadu",
+    "state_code": "AP"
+  },
+  {
+    "id": 132388,
+    "name": "Kanuru",
+    "state_code": "AP"
+  },
+  {
+    "id": 132729,
+    "name": "Kavali",
+    "state_code": "AP"
+  },
+  {
+    "id": 132552,
+    "name": "Kolanukonda",
+    "state_code": "AP"
+  },
+  {
+    "id": 132567,
+    "name": "Kondapalle",
+    "state_code": "AP"
+  },
+  {
+    "id": 132584,
+    "name": "Korukollu",
+    "state_code": "AP"
+  },
+  {
+    "id": 132590,
+    "name": "Kosigi",
+    "state_code": "AP"
+  },
+  {
+    "id": 132616,
+    "name": "Kovvur",
+    "state_code": "AP"
+  },
+  {
+    "id": 132621,
+    "name": "Krishna",
+    "state_code": "AP"
+  },
+  {
+    "id": 132653,
+    "name": "Kuppam",
+    "state_code": "AP"
+  },
+  {
+    "id": 132660,
+    "name": "Kurnool",
+    "state_code": "AP"
+  },
+  {
+    "id": 133055,
+    "name": "Macherla",
+    "state_code": "AP"
+  },
+  {
+    "id": 132806,
+    "name": "Machilipatnam",
+    "state_code": "AP"
+  },
+  {
+    "id": 132808,
+    "name": "Madanapalle",
+    "state_code": "AP"
+  },
+  {
+    "id": 133059,
+    "name": "Madugula",
+    "state_code": "AP"
+  },
+  {
+    "id": 132890,
+    "name": "Mandapeta",
+    "state_code": "AP"
+  },
+  {
+    "id": 132891,
+    "name": "Mandasa",
+    "state_code": "AP"
+  },
+  {
+    "id": 132902,
+    "name": "Mangalagiri",
+    "state_code": "AP"
+  },
+  {
+    "id": 133088,
+    "name": "Markapur",
+    "state_code": "AP"
+  },
+  {
+    "id": 133114,
+    "name": "Nagari",
+    "state_code": "AP"
+  },
+  {
+    "id": 133258,
+    "name": "Nagireddipalli",
+    "state_code": "AP"
+  },
+  {
+    "id": 133143,
+    "name": "Nandigama",
+    "state_code": "AP"
+  },
+  {
+    "id": 133144,
+    "name": "Nandikotkur",
+    "state_code": "AP"
+  },
+  {
+    "id": 133146,
+    "name": "Nandyal",
+    "state_code": "AP"
+  },
+  {
+    "id": 133156,
+    "name": "Narasannapeta",
+    "state_code": "AP"
+  },
+  {
+    "id": 133157,
+    "name": "Narasapur",
+    "state_code": "AP"
+  },
+  {
+    "id": 133158,
+    "name": "Narasaraopet",
+    "state_code": "AP"
+  },
+  {
+    "id": 133160,
+    "name": "Narasingapuram",
+    "state_code": "AP"
+  },
+  {
+    "id": 133275,
+    "name": "Narayanavanam",
+    "state_code": "AP"
+  },
+  {
+    "id": 133173,
+    "name": "Narsipatnam",
+    "state_code": "AP"
+  },
+  {
+    "id": 133283,
+    "name": "Nayudupet",
+    "state_code": "AP"
+  },
+  {
+    "id": 133206,
+    "name": "Nellore",
+    "state_code": "AP"
+  },
+  {
+    "id": 133214,
+    "name": "Nidadavole",
+    "state_code": "AP"
+  },
+  {
+    "id": 133294,
+    "name": "Nuzvid",
+    "state_code": "AP"
+  },
+  {
+    "id": 133300,
+    "name": "Ongole",
+    "state_code": "AP"
+  },
+  {
+    "id": 133521,
+    "name": "Pakala",
+    "state_code": "AP"
+  },
+  {
+    "id": 133523,
+    "name": "Palakollu",
+    "state_code": "AP"
+  },
+  {
+    "id": 133340,
+    "name": "Palasa",
+    "state_code": "AP"
+  },
+  {
+    "id": 133534,
+    "name": "Palkonda",
+    "state_code": "AP"
+  },
+  {
+    "id": 133331,
+    "name": "Pallevada",
+    "state_code": "AP"
+  },
+  {
+    "id": 133336,
+    "name": "Palmaner",
+    "state_code": "AP"
+  },
+  {
+    "id": 133361,
+    "name": "Parlakimidi",
+    "state_code": "AP"
+  },
+  {
+    "id": 133549,
+    "name": "Parvatipuram",
+    "state_code": "AP"
+  },
+  {
+    "id": 133395,
+    "name": "Pavuluru",
+    "state_code": "AP"
+  },
+  {
+    "id": 133400,
+    "name": "Pedana",
+    "state_code": "AP"
+  },
+  {
+    "id": 134447,
+    "name": "pedda nakkalapalem",
+    "state_code": "AP"
+  },
+  {
+    "id": 133402,
+    "name": "Peddapuram",
+    "state_code": "AP"
+  },
+  {
+    "id": 133409,
+    "name": "Penugonda",
+    "state_code": "AP"
+  },
+  {
+    "id": 133410,
+    "name": "Penukonda",
+    "state_code": "AP"
+  },
+  {
+    "id": 133440,
+    "name": "Phirangipuram",
+    "state_code": "AP"
+  },
+  {
+    "id": 133455,
+    "name": "Pippara",
+    "state_code": "AP"
+  },
+  {
+    "id": 133465,
+    "name": "Pithapuram",
+    "state_code": "AP"
+  },
+  {
+    "id": 133468,
+    "name": "Polavaram",
+    "state_code": "AP"
+  },
+  {
+    "id": 133476,
+    "name": "Ponnur",
+    "state_code": "AP"
+  },
+  {
+    "id": 133478,
+    "name": "Ponnuru",
+    "state_code": "AP"
+  },
+  {
+    "id": 133485,
+    "name": "Prakasam",
+    "state_code": "AP"
+  },
+  {
+    "id": 133489,
+    "name": "Proddatur",
+    "state_code": "AP"
+  },
+  {
+    "id": 133497,
+    "name": "Pulivendla",
+    "state_code": "AP"
+  },
+  {
+    "id": 133506,
+    "name": "Punganuru",
+    "state_code": "AP"
+  },
+  {
+    "id": 133517,
+    "name": "Puttaparthi",
+    "state_code": "AP"
+  },
+  {
+    "id": 133519,
+    "name": "Puttur",
+    "state_code": "AP"
+  },
+  {
+    "id": 133671,
+    "name": "Rajahmundry",
+    "state_code": "AP"
+  },
+  {
+    "id": 133691,
+    "name": "Ramachandrapuram",
+    "state_code": "AP"
+  },
+  {
+    "id": 133600,
+    "name": "Ramanayyapeta",
+    "state_code": "AP"
+  },
+  {
+    "id": 133712,
+    "name": "Ramapuram",
+    "state_code": "AP"
+  },
+  {
+    "id": 133605,
+    "name": "Rampachodavaram",
+    "state_code": "AP"
+  },
+  {
+    "id": 133729,
+    "name": "Rayachoti",
+    "state_code": "AP"
+  },
+  {
+    "id": 133730,
+    "name": "Rayadrug",
+    "state_code": "AP"
+  },
+  {
+    "id": 133734,
+    "name": "Razam",
+    "state_code": "AP"
+  },
+  {
+    "id": 133732,
+    "name": "Razampeta",
+    "state_code": "AP"
+  },
+  {
+    "id": 133733,
+    "name": "Razole",
+    "state_code": "AP"
+  },
+  {
+    "id": 133627,
+    "name": "Renigunta",
+    "state_code": "AP"
+  },
+  {
+    "id": 133630,
+    "name": "Repalle",
+    "state_code": "AP"
+  },
+  {
+    "id": 134065,
+    "name": "Salur",
+    "state_code": "AP"
+  },
+  {
+    "id": 134066,
+    "name": "Samalkot",
+    "state_code": "AP"
+  },
+  {
+    "id": 133822,
+    "name": "Sattenapalle",
+    "state_code": "AP"
+  },
+  {
+    "id": 133946,
+    "name": "Singarayakonda",
+    "state_code": "AP"
+  },
+  {
+    "id": 133990,
+    "name": "Sompeta",
+    "state_code": "AP"
+  },
+  {
+    "id": 134019,
+    "name": "Srikakulam",
+    "state_code": "AP"
+  },
+  {
+    "id": 134032,
+    "name": "Srisailain",
+    "state_code": "AP"
+  },
+  {
+    "id": 134093,
+    "name": "Suluru",
+    "state_code": "AP"
+  },
+  {
+    "id": 134226,
+    "name": "Tadepalle",
+    "state_code": "AP"
+  },
+  {
+    "id": 134227,
+    "name": "Tadepallegudem",
+    "state_code": "AP"
+  },
+  {
+    "id": 134228,
+    "name": "Tadpatri",
+    "state_code": "AP"
+  },
+  {
+    "id": 134113,
+    "name": "Tanuku",
+    "state_code": "AP"
+  },
+  {
+    "id": 134126,
+    "name": "Tekkali",
+    "state_code": "AP"
+  },
+  {
+    "id": 134183,
+    "name": "Tirumala",
+    "state_code": "AP"
+  },
+  {
+    "id": 134187,
+    "name": "Tirupati",
+    "state_code": "AP"
+  },
+  {
+    "id": 134222,
+    "name": "Tuni",
+    "state_code": "AP"
+  },
+  {
+    "id": 134292,
+    "name": "Uravakonda",
+    "state_code": "AP"
+  },
+  {
+    "id": 134448,
+    "name": "vadlamuru",
+    "state_code": "AP"
+  },
+  {
+    "id": 134308,
+    "name": "Vadlapudi",
+    "state_code": "AP"
+  },
+  {
+    "id": 134347,
+    "name": "Venkatagiri",
+    "state_code": "AP"
+  },
+  {
+    "id": 134348,
+    "name": "Vepagunta",
+    "state_code": "AP"
+  },
+  {
+    "id": 134350,
+    "name": "Vetapalem",
+    "state_code": "AP"
+  },
+  {
+    "id": 134356,
+    "name": "Vijayawada",
+    "state_code": "AP"
+  },
+  {
+    "id": 134364,
+    "name": "Vinukonda",
+    "state_code": "AP"
+  },
+  {
+    "id": 134369,
+    "name": "Visakhapatnam",
+    "state_code": "AP"
+  },
+  {
+    "id": 134373,
+    "name": "Vizianagaram",
+    "state_code": "AP"
+  },
+  {
+    "id": 134374,
+    "name": "Vizianagaram District",
+    "state_code": "AP"
+  },
+  {
+    "id": 134377,
+    "name": "Vuyyuru",
+    "state_code": "AP"
+  },
+  {
+    "id": 134407,
+    "name": "West Godavari",
+    "state_code": "AP"
+  },
+  {
+    "id": 134424,
+    "name": "Yanam",
+    "state_code": "AP"
+  },
+  {
+    "id": 134426,
+    "name": "Yanamalakuduru",
+    "state_code": "AP"
+  },
+  {
+    "id": 134437,
+    "name": "Yarada",
+    "state_code": "AP"
+  },
+  {
+    "id": 57645,
+    "name": "Along",
+    "state_code": "AR"
+  },
+  {
+    "id": 57708,
+    "name": "Anjaw",
+    "state_code": "AR"
+  },
+  {
+    "id": 58151,
+    "name": "Basar",
+    "state_code": "AR"
+  },
+  {
+    "id": 58080,
+    "name": "Bomdila",
+    "state_code": "AR"
+  },
+  {
+    "id": 58196,
+    "name": "Changlang",
+    "state_code": "AR"
+  },
+  {
+    "id": 131763,
+    "name": "Dibang Valley",
+    "state_code": "AR"
+  },
+  {
+    "id": 131826,
+    "name": "East Kameng",
+    "state_code": "AR"
+  },
+  {
+    "id": 131828,
+    "name": "East Siang",
+    "state_code": "AR"
+  },
+  {
+    "id": 132090,
+    "name": "Hayuliang",
+    "state_code": "AR"
+  },
+  {
+    "id": 132178,
+    "name": "Itanagar",
+    "state_code": "AR"
+  },
+  {
+    "id": 132499,
+    "name": "Khonsa",
+    "state_code": "AR"
+  },
+  {
+    "id": 132663,
+    "name": "Kurung Kumey",
+    "state_code": "AR"
+  },
+  {
+    "id": 132769,
+    "name": "Lohit District",
+    "state_code": "AR"
+  },
+  {
+    "id": 132779,
+    "name": "Lower Dibang Valley",
+    "state_code": "AR"
+  },
+  {
+    "id": 132780,
+    "name": "Lower Subansiri",
+    "state_code": "AR"
+  },
+  {
+    "id": 132934,
+    "name": "Margherita",
+    "state_code": "AR"
+  },
+  {
+    "id": 133121,
+    "name": "Naharlagun",
+    "state_code": "AR"
+  },
+  {
+    "id": 133551,
+    "name": "Pasighat",
+    "state_code": "AR"
+  },
+  {
+    "id": 134120,
+    "name": "Tawang",
+    "state_code": "AR"
+  },
+  {
+    "id": 134135,
+    "name": "Tezu",
+    "state_code": "AR"
+  },
+  {
+    "id": 134199,
+    "name": "Tirap",
+    "state_code": "AR"
+  },
+  {
+    "id": 134288,
+    "name": "Upper Siang",
+    "state_code": "AR"
+  },
+  {
+    "id": 134289,
+    "name": "Upper Subansiri",
+    "state_code": "AR"
+  },
+  {
+    "id": 134409,
+    "name": "West Kameng",
+    "state_code": "AR"
+  },
+  {
+    "id": 134411,
+    "name": "West Siang",
+    "state_code": "AR"
+  },
+  {
+    "id": 134444,
+    "name": "Ziro",
+    "state_code": "AR"
+  },
+  {
+    "id": 57585,
+    "name": "Abhayapuri",
+    "state_code": "AS"
+  },
+  {
+    "id": 57679,
+    "name": "Amguri",
+    "state_code": "AS"
+  },
+  {
+    "id": 57787,
+    "name": "Badarpur",
+    "state_code": "AS"
+  },
+  {
+    "id": 57820,
+    "name": "Baksa",
+    "state_code": "AS"
+  },
+  {
+    "id": 57883,
+    "name": "Barpathar",
+    "state_code": "AS"
+  },
+  {
+    "id": 57884,
+    "name": "Barpeta",
+    "state_code": "AS"
+  },
+  {
+    "id": 57885,
+    "name": "Barpeta Road",
+    "state_code": "AS"
+  },
+  {
+    "id": 58150,
+    "name": "Basugaon",
+    "state_code": "AS"
+  },
+  {
+    "id": 58028,
+    "name": "Bihpuriagaon",
+    "state_code": "AS"
+  },
+  {
+    "id": 58034,
+    "name": "Bijni",
+    "state_code": "AS"
+  },
+  {
+    "id": 58053,
+    "name": "Bilasipara",
+    "state_code": "AS"
+  },
+  {
+    "id": 58075,
+    "name": "Bokajan",
+    "state_code": "AS"
+  },
+  {
+    "id": 58077,
+    "name": "Bokakhat",
+    "state_code": "AS"
+  },
+  {
+    "id": 58081,
+    "name": "Bongaigaon",
+    "state_code": "AS"
+  },
+  {
+    "id": 131634,
+    "name": "Cachar",
+    "state_code": "AS"
+  },
+  {
+    "id": 131588,
+    "name": "Chabua",
+    "state_code": "AS"
+  },
+  {
+    "id": 131604,
+    "name": "Chapar",
+    "state_code": "AS"
+  },
+  {
+    "id": 131568,
+    "name": "Chirang",
+    "state_code": "AS"
+  },
+  {
+    "id": 131657,
+    "name": "Darrang",
+    "state_code": "AS"
+  },
+  {
+    "id": 131695,
+    "name": "Dergaon",
+    "state_code": "AS"
+  },
+  {
+    "id": 131732,
+    "name": "Dhekiajuli",
+    "state_code": "AS"
+  },
+  {
+    "id": 131733,
+    "name": "Dhemaji",
+    "state_code": "AS"
+  },
+  {
+    "id": 131737,
+    "name": "Dhing",
+    "state_code": "AS"
+  },
+  {
+    "id": 131744,
+    "name": "Dhubri",
+    "state_code": "AS"
+  },
+  {
+    "id": 131762,
+    "name": "Dibrugarh",
+    "state_code": "AS"
+  },
+  {
+    "id": 131766,
+    "name": "Digboi",
+    "state_code": "AS"
+  },
+  {
+    "id": 131770,
+    "name": "Dima Hasao District",
+    "state_code": "AS"
+  },
+  {
+    "id": 131776,
+    "name": "Diphu",
+    "state_code": "AS"
+  },
+  {
+    "id": 131778,
+    "name": "Dispur",
+    "state_code": "AS"
+  },
+  {
+    "id": 131795,
+    "name": "Duliagaon",
+    "state_code": "AS"
+  },
+  {
+    "id": 131796,
+    "name": "Dum Duma",
+    "state_code": "AS"
+  },
+  {
+    "id": 131928,
+    "name": "Gauripur",
+    "state_code": "AS"
+  },
+  {
+    "id": 132004,
+    "name": "Goalpara",
+    "state_code": "AS"
+  },
+  {
+    "id": 131967,
+    "name": "Gohpur",
+    "state_code": "AS"
+  },
+  {
+    "id": 131976,
+    "name": "Golaghat",
+    "state_code": "AS"
+  },
+  {
+    "id": 131977,
+    "name": "Golakganj",
+    "state_code": "AS"
+  },
+  {
+    "id": 131997,
+    "name": "Goshaingaon",
+    "state_code": "AS"
+  },
+  {
+    "id": 132039,
+    "name": "Guwahati",
+    "state_code": "AS"
+  },
+  {
+    "id": 132134,
+    "name": "Haflong",
+    "state_code": "AS"
+  },
+  {
+    "id": 132055,
+    "name": "Hailakandi",
+    "state_code": "AS"
+  },
+  {
+    "id": 132137,
+    "name": "Hajo",
+    "state_code": "AS"
+  },
+  {
+    "id": 132110,
+    "name": "Hojai",
+    "state_code": "AS"
+  },
+  {
+    "id": 132126,
+    "name": "Howli",
+    "state_code": "AS"
+  },
+  {
+    "id": 132291,
+    "name": "Jogighopa",
+    "state_code": "AS"
+  },
+  {
+    "id": 132294,
+    "name": "Jorhat",
+    "state_code": "AS"
+  },
+  {
+    "id": 132693,
+    "name": "Kamrup",
+    "state_code": "AS"
+  },
+  {
+    "id": 132366,
+    "name": "Kamrup Metropolitan",
+    "state_code": "AS"
+  },
+  {
+    "id": 132718,
+    "name": "Karbi Anglong",
+    "state_code": "AS"
+  },
+  {
+    "id": 132402,
+    "name": "Karimganj",
+    "state_code": "AS"
+  },
+  {
+    "id": 132518,
+    "name": "Kharupatia",
+    "state_code": "AS"
+  },
+  {
+    "id": 132551,
+    "name": "Kokrajhar",
+    "state_code": "AS"
+  },
+  {
+    "id": 132742,
+    "name": "Lakhimpur",
+    "state_code": "AS"
+  },
+  {
+    "id": 132743,
+    "name": "Lakhipur",
+    "state_code": "AS"
+  },
+  {
+    "id": 132793,
+    "name": "Lala",
+    "state_code": "AS"
+  },
+  {
+    "id": 132786,
+    "name": "Lumding Railway Colony",
+    "state_code": "AS"
+  },
+  {
+    "id": 132842,
+    "name": "Mahur",
+    "state_code": "AS"
+  },
+  {
+    "id": 132853,
+    "name": "Maibong",
+    "state_code": "AS"
+  },
+  {
+    "id": 133064,
+    "name": "Makum",
+    "state_code": "AS"
+  },
+  {
+    "id": 132904,
+    "name": "Mangaldai",
+    "state_code": "AS"
+  },
+  {
+    "id": 132937,
+    "name": "Mariani",
+    "state_code": "AS"
+  },
+  {
+    "id": 133002,
+    "name": "Moranha",
+    "state_code": "AS"
+  },
+  {
+    "id": 132995,
+    "name": "Morigaon",
+    "state_code": "AS"
+  },
+  {
+    "id": 133110,
+    "name": "Nagaon",
+    "state_code": "AS"
+  },
+  {
+    "id": 133122,
+    "name": "Nahorkatiya",
+    "state_code": "AS"
+  },
+  {
+    "id": 133130,
+    "name": "Nalbari",
+    "state_code": "AS"
+  },
+  {
+    "id": 133266,
+    "name": "Namrup",
+    "state_code": "AS"
+  },
+  {
+    "id": 133284,
+    "name": "Nazira",
+    "state_code": "AS"
+  },
+  {
+    "id": 133239,
+    "name": "North Guwahati",
+    "state_code": "AS"
+  },
+  {
+    "id": 133240,
+    "name": "North Lakhimpur",
+    "state_code": "AS"
+  },
+  {
+    "id": 133248,
+    "name": "Numaligarh",
+    "state_code": "AS"
+  },
+  {
+    "id": 133341,
+    "name": "Palasbari",
+    "state_code": "AS"
+  },
+  {
+    "id": 133584,
+    "name": "Raha",
+    "state_code": "AS"
+  },
+  {
+    "id": 133610,
+    "name": "Rangapara",
+    "state_code": "AS"
+  },
+  {
+    "id": 133608,
+    "name": "Rangia",
+    "state_code": "AS"
+  },
+  {
+    "id": 133798,
+    "name": "Sapatgram",
+    "state_code": "AS"
+  },
+  {
+    "id": 133809,
+    "name": "Sarupathar",
+    "state_code": "AS"
+  },
+  {
+    "id": 133916,
+    "name": "Sibsagar",
+    "state_code": "AS"
+  },
+  {
+    "id": 133934,
+    "name": "Silapathar",
+    "state_code": "AS"
+  },
+  {
+    "id": 133935,
+    "name": "Silchar",
+    "state_code": "AS"
+  },
+  {
+    "id": 133979,
+    "name": "Soalkuchi",
+    "state_code": "AS"
+  },
+  {
+    "id": 133998,
+    "name": "Sonari",
+    "state_code": "AS"
+  },
+  {
+    "id": 133996,
+    "name": "Sonitpur",
+    "state_code": "AS"
+  },
+  {
+    "id": 134003,
+    "name": "Sorbhog",
+    "state_code": "AS"
+  },
+  {
+    "id": 134134,
+    "name": "Tezpur",
+    "state_code": "AS"
+  },
+  {
+    "id": 134175,
+    "name": "Tinsukia",
+    "state_code": "AS"
+  },
+  {
+    "id": 134203,
+    "name": "Titabar",
+    "state_code": "AS"
+  },
+  {
+    "id": 134252,
+    "name": "Udalguri",
+    "state_code": "AS"
+  },
+  {
+    "id": 57661,
+    "name": "Amarpur",
+    "state_code": "BR"
+  },
+  {
+    "id": 57730,
+    "name": "Araria",
+    "state_code": "BR"
+  },
+  {
+    "id": 57739,
+    "name": "Arrah",
+    "state_code": "BR"
+  },
+  {
+    "id": 57747,
+    "name": "Arwal",
+    "state_code": "BR"
+  },
+  {
+    "id": 57749,
+    "name": "Asarganj",
+    "state_code": "BR"
+  },
+  {
+    "id": 57766,
+    "name": "Aurangabad",
+    "state_code": "BR"
+  },
+  {
+    "id": 57796,
+    "name": "Bagaha",
+    "state_code": "BR"
+  },
+  {
+    "id": 57809,
+    "name": "Bahadurganj",
+    "state_code": "BR"
+  },
+  {
+    "id": 57815,
+    "name": "Bairagnia",
+    "state_code": "BR"
+  },
+  {
+    "id": 57816,
+    "name": "Baisi",
+    "state_code": "BR"
+  },
+  {
+    "id": 57818,
+    "name": "Bakhtiyarpur",
+    "state_code": "BR"
+  },
+  {
+    "id": 57850,
+    "name": "Bangaon",
+    "state_code": "BR"
+  },
+  {
+    "id": 57854,
+    "name": "Banka",
+    "state_code": "BR"
+  },
+  {
+    "id": 57855,
+    "name": "Banmankhi",
+    "state_code": "BR"
+  },
+  {
+    "id": 57860,
+    "name": "Bar Bigha",
+    "state_code": "BR"
+  },
+  {
+    "id": 57864,
+    "name": "Barauli",
+    "state_code": "BR"
+  },
+  {
+    "id": 58141,
+    "name": "Barh",
+    "state_code": "BR"
+  },
+  {
+    "id": 57873,
+    "name": "Barhiya",
+    "state_code": "BR"
+  },
+  {
+    "id": 57875,
+    "name": "Bariarpur",
+    "state_code": "BR"
+  },
+  {
+    "id": 58145,
+    "name": "Baruni",
+    "state_code": "BR"
+  },
+  {
+    "id": 57915,
+    "name": "Begusarai",
+    "state_code": "BR"
+  },
+  {
+    "id": 57927,
+    "name": "Belsand",
+    "state_code": "BR"
+  },
+  {
+    "id": 57941,
+    "name": "Bettiah",
+    "state_code": "BR"
+  },
+  {
+    "id": 57947,
+    "name": "Bhabhua",
+    "state_code": "BR"
+  },
+  {
+    "id": 58009,
+    "name": "Bhagalpur",
+    "state_code": "BR"
+  },
+  {
+    "id": 57957,
+    "name": "Bhagirathpur",
+    "state_code": "BR"
+  },
+  {
+    "id": 57974,
+    "name": "Bhawanipur",
+    "state_code": "BR"
+  },
+  {
+    "id": 57991,
+    "name": "Bhojpur",
+    "state_code": "BR"
+  },
+  {
+    "id": 58029,
+    "name": "Bihar Sharif",
+    "state_code": "BR"
+  },
+  {
+    "id": 58030,
+    "name": "Bihariganj",
+    "state_code": "BR"
+  },
+  {
+    "id": 58039,
+    "name": "Bikramganj",
+    "state_code": "BR"
+  },
+  {
+    "id": 58160,
+    "name": "Birpur",
+    "state_code": "BR"
+  },
+  {
+    "id": 58089,
+    "name": "Bodh Gaya",
+    "state_code": "BR"
+  },
+  {
+    "id": 58100,
+    "name": "Buxar",
+    "state_code": "BR"
+  },
+  {
+    "id": 131590,
+    "name": "Chakia",
+    "state_code": "BR"
+  },
+  {
+    "id": 131605,
+    "name": "Chapra",
+    "state_code": "BR"
+  },
+  {
+    "id": 131541,
+    "name": "Chhatapur",
+    "state_code": "BR"
+  },
+  {
+    "id": 131620,
+    "name": "Colgong",
+    "state_code": "BR"
+  },
+  {
+    "id": 131647,
+    "name": "Dalsingh Sarai",
+    "state_code": "BR"
+  },
+  {
+    "id": 131654,
+    "name": "Darbhanga",
+    "state_code": "BR"
+  },
+  {
+    "id": 131664,
+    "name": "Daudnagar",
+    "state_code": "BR"
+  },
+  {
+    "id": 131677,
+    "name": "Dehri",
+    "state_code": "BR"
+  },
+  {
+    "id": 131748,
+    "name": "Dhaka",
+    "state_code": "BR"
+  },
+  {
+    "id": 131767,
+    "name": "Dighwara",
+    "state_code": "BR"
+  },
+  {
+    "id": 131773,
+    "name": "Dinapore",
+    "state_code": "BR"
+  },
+  {
+    "id": 131798,
+    "name": "Dumra",
+    "state_code": "BR"
+  },
+  {
+    "id": 131799,
+    "name": "Dumraon",
+    "state_code": "BR"
+  },
+  {
+    "id": 131873,
+    "name": "Fatwa",
+    "state_code": "BR"
+  },
+  {
+    "id": 131878,
+    "name": "Forbesganj",
+    "state_code": "BR"
+  },
+  {
+    "id": 131932,
+    "name": "Gaya",
+    "state_code": "BR"
+  },
+  {
+    "id": 131943,
+    "name": "Ghoga",
+    "state_code": "BR"
+  },
+  {
+    "id": 131987,
+    "name": "Gopalganj",
+    "state_code": "BR"
+  },
+  {
+    "id": 132138,
+    "name": "Hajipur",
+    "state_code": "BR"
+  },
+  {
+    "id": 132095,
+    "name": "Hilsa",
+    "state_code": "BR"
+  },
+  {
+    "id": 132107,
+    "name": "Hisua",
+    "state_code": "BR"
+  },
+  {
+    "id": 132174,
+    "name": "Islampur",
+    "state_code": "BR"
+  },
+  {
+    "id": 132188,
+    "name": "Jagdispur",
+    "state_code": "BR"
+  },
+  {
+    "id": 132198,
+    "name": "Jahanabad",
+    "state_code": "BR"
+  },
+  {
+    "id": 132234,
+    "name": "Jamalpur",
+    "state_code": "BR"
+  },
+  {
+    "id": 132233,
+    "name": "Jamui",
+    "state_code": "BR"
+  },
+  {
+    "id": 132258,
+    "name": "Jaynagar",
+    "state_code": "BR"
+  },
+  {
+    "id": 132259,
+    "name": "Jehanabad",
+    "state_code": "BR"
+  },
+  {
+    "id": 132274,
+    "name": "Jha-Jha",
+    "state_code": "BR"
+  },
+  {
+    "id": 132267,
+    "name": "Jhanjharpur",
+    "state_code": "BR"
+  },
+  {
+    "id": 132288,
+    "name": "Jogbani",
+    "state_code": "BR"
+  },
+  {
+    "id": 132337,
+    "name": "Kaimur District",
+    "state_code": "BR"
+  },
+  {
+    "id": 132417,
+    "name": "Kasba",
+    "state_code": "BR"
+  },
+  {
+    "id": 132423,
+    "name": "Katihar",
+    "state_code": "BR"
+  },
+  {
+    "id": 132451,
+    "name": "Khagaria",
+    "state_code": "BR"
+  },
+  {
+    "id": 132452,
+    "name": "Khagaul",
+    "state_code": "BR"
+  },
+  {
+    "id": 132470,
+    "name": "Kharagpur",
+    "state_code": "BR"
+  },
+  {
+    "id": 132510,
+    "name": "Khusropur",
+    "state_code": "BR"
+  },
+  {
+    "id": 132529,
+    "name": "Kishanganj",
+    "state_code": "BR"
+  },
+  {
+    "id": 132620,
+    "name": "Koath",
+    "state_code": "BR"
+  },
+  {
+    "id": 132548,
+    "name": "Koelwar",
+    "state_code": "BR"
+  },
+  {
+    "id": 132744,
+    "name": "Lakhisarai",
+    "state_code": "BR"
+  },
+  {
+    "id": 132795,
+    "name": "Lalganj",
+    "state_code": "BR"
+  },
+  {
+    "id": 132781,
+    "name": "Luckeesarai",
+    "state_code": "BR"
+  },
+  {
+    "id": 132812,
+    "name": "Madhepura",
+    "state_code": "BR"
+  },
+  {
+    "id": 132815,
+    "name": "Madhubani",
+    "state_code": "BR"
+  },
+  {
+    "id": 132849,
+    "name": "Maharajgani",
+    "state_code": "BR"
+  },
+  {
+    "id": 132859,
+    "name": "Mairwa",
+    "state_code": "BR"
+  },
+  {
+    "id": 132901,
+    "name": "Maner",
+    "state_code": "BR"
+  },
+  {
+    "id": 132911,
+    "name": "Manihari",
+    "state_code": "BR"
+  },
+  {
+    "id": 132935,
+    "name": "Marhaura",
+    "state_code": "BR"
+  },
+  {
+    "id": 132938,
+    "name": "Masaurhi Buzurg",
+    "state_code": "BR"
+  },
+  {
+    "id": 132984,
+    "name": "Mohiuddi nagar",
+    "state_code": "BR"
+  },
+  {
+    "id": 132988,
+    "name": "Mokameh",
+    "state_code": "BR"
+  },
+  {
+    "id": 132991,
+    "name": "Monghyr",
+    "state_code": "BR"
+  },
+  {
+    "id": 133005,
+    "name": "Mothihari",
+    "state_code": "BR"
+  },
+  {
+    "id": 133032,
+    "name": "Munger",
+    "state_code": "BR"
+  },
+  {
+    "id": 133037,
+    "name": "Murliganj",
+    "state_code": "BR"
+  },
+  {
+    "id": 133052,
+    "name": "Muzaffarpur",
+    "state_code": "BR"
+  },
+  {
+    "id": 133105,
+    "name": "Nabinagar",
+    "state_code": "BR"
+  },
+  {
+    "id": 133262,
+    "name": "Nalanda",
+    "state_code": "BR"
+  },
+  {
+    "id": 133279,
+    "name": "Nasriganj",
+    "state_code": "BR"
+  },
+  {
+    "id": 133182,
+    "name": "Naugachhia",
+    "state_code": "BR"
+  },
+  {
+    "id": 133192,
+    "name": "Nawada",
+    "state_code": "BR"
+  },
+  {
+    "id": 133222,
+    "name": "Nirmali",
+    "state_code": "BR"
+  },
+  {
+    "id": 133373,
+    "name": "Pashchim Champaran",
+    "state_code": "BR"
+  },
+  {
+    "id": 133386,
+    "name": "Patna",
+    "state_code": "BR"
+  },
+  {
+    "id": 133459,
+    "name": "Piro",
+    "state_code": "BR"
+  },
+  {
+    "id": 133509,
+    "name": "Pupri",
+    "state_code": "BR"
+  },
+  {
+    "id": 133570,
+    "name": "Purba Champaran",
+    "state_code": "BR"
+  },
+  {
+    "id": 133512,
+    "name": "Purnia",
+    "state_code": "BR"
+  },
+  {
+    "id": 133581,
+    "name": "Rafiganj",
+    "state_code": "BR"
+  },
+  {
+    "id": 133582,
+    "name": "Raghunathpur",
+    "state_code": "BR"
+  },
+  {
+    "id": 133678,
+    "name": "Rajgir",
+    "state_code": "BR"
+  },
+  {
+    "id": 133701,
+    "name": "Ramnagar",
+    "state_code": "BR"
+  },
+  {
+    "id": 133621,
+    "name": "Raxaul",
+    "state_code": "BR"
+  },
+  {
+    "id": 133632,
+    "name": "Revelganj",
+    "state_code": "BR"
+  },
+  {
+    "id": 133648,
+    "name": "Rohtas",
+    "state_code": "BR"
+  },
+  {
+    "id": 133656,
+    "name": "Rusera",
+    "state_code": "BR"
+  },
+  {
+    "id": 133748,
+    "name": "Sagauli",
+    "state_code": "BR"
+  },
+  {
+    "id": 133749,
+    "name": "Saharsa",
+    "state_code": "BR"
+  },
+  {
+    "id": 133767,
+    "name": "Samastipur",
+    "state_code": "BR"
+  },
+  {
+    "id": 134076,
+    "name": "Saran",
+    "state_code": "BR"
+  },
+  {
+    "id": 133852,
+    "name": "Shahbazpur",
+    "state_code": "BR"
+  },
+  {
+    "id": 133902,
+    "name": "Shahpur",
+    "state_code": "BR"
+  },
+  {
+    "id": 133858,
+    "name": "Sheikhpura",
+    "state_code": "BR"
+  },
+  {
+    "id": 133860,
+    "name": "Sheohar",
+    "state_code": "BR"
+  },
+  {
+    "id": 133863,
+    "name": "Sherghati",
+    "state_code": "BR"
+  },
+  {
+    "id": 133933,
+    "name": "Silao",
+    "state_code": "BR"
+  },
+  {
+    "id": 134089,
+    "name": "Sitamarhi",
+    "state_code": "BR"
+  },
+  {
+    "id": 133977,
+    "name": "Siwan",
+    "state_code": "BR"
+  },
+  {
+    "id": 134049,
+    "name": "Supaul",
+    "state_code": "BR"
+  },
+  {
+    "id": 134121,
+    "name": "Teghra",
+    "state_code": "BR"
+  },
+  {
+    "id": 134127,
+    "name": "Tekari",
+    "state_code": "BR"
+  },
+  {
+    "id": 134163,
+    "name": "Thakurganj",
+    "state_code": "BR"
+  },
+  {
+    "id": 134314,
+    "name": "Vaishali",
+    "state_code": "BR"
+  },
+  {
+    "id": 134417,
+    "name": "Waris Aliganj",
+    "state_code": "BR"
+  },
+  {
+    "id": 58190,
+    "name": "Chandigarh",
+    "state_code": "CH"
+  },
+  {
+    "id": 57619,
+    "name": "Akaltara",
+    "state_code": "CT"
+  },
+  {
+    "id": 57672,
+    "name": "Ambagarh Chauki",
+    "state_code": "CT"
+  },
+  {
+    "id": 57670,
+    "name": "Ambikapur",
+    "state_code": "CT"
+  },
+  {
+    "id": 57728,
+    "name": "Arang",
+    "state_code": "CT"
+  },
+  {
+    "id": 57812,
+    "name": "Baikunthpur",
+    "state_code": "CT"
+  },
+  {
+    "id": 57830,
+    "name": "Balod",
+    "state_code": "CT"
+  },
+  {
+    "id": 57831,
+    "name": "Baloda",
+    "state_code": "CT"
+  },
+  {
+    "id": 57832,
+    "name": "Baloda Bazar",
+    "state_code": "CT"
+  },
+  {
+    "id": 57898,
+    "name": "Basna",
+    "state_code": "CT"
+  },
+  {
+    "id": 57900,
+    "name": "Bastar",
+    "state_code": "CT"
+  },
+  {
+    "id": 57931,
+    "name": "Bemetara",
+    "state_code": "CT"
+  },
+  {
+    "id": 58013,
+    "name": "Bhanpuri",
+    "state_code": "CT"
+  },
+  {
+    "id": 58015,
+    "name": "Bhatapara",
+    "state_code": "CT"
+  },
+  {
+    "id": 57969,
+    "name": "Bhatgaon",
+    "state_code": "CT"
+  },
+  {
+    "id": 57981,
+    "name": "Bhilai",
+    "state_code": "CT"
+  },
+  {
+    "id": 58032,
+    "name": "Bijapur",
+    "state_code": "CT"
+  },
+  {
+    "id": 58055,
+    "name": "Bilaspur",
+    "state_code": "CT"
+  },
+  {
+    "id": 131593,
+    "name": "Champa",
+    "state_code": "CT"
+  },
+  {
+    "id": 131538,
+    "name": "Chhuikhadan",
+    "state_code": "CT"
+  },
+  {
+    "id": 153519,
+    "name": "Dantewada",
+    "state_code": "CT"
+  },
+  {
+    "id": 131690,
+    "name": "Deori",
+    "state_code": "CT"
+  },
+  {
+    "id": 131712,
+    "name": "Dhamtari",
+    "state_code": "CT"
+  },
+  {
+    "id": 131787,
+    "name": "Dongargaon",
+    "state_code": "CT"
+  },
+  {
+    "id": 131788,
+    "name": "Dongargarh",
+    "state_code": "CT"
+  },
+  {
+    "id": 131801,
+    "name": "Durg",
+    "state_code": "CT"
+  },
+  {
+    "id": 131897,
+    "name": "Gandai",
+    "state_code": "CT"
+  },
+  {
+    "id": 131926,
+    "name": "Gariaband",
+    "state_code": "CT"
+  },
+  {
+    "id": 131927,
+    "name": "Gaurela",
+    "state_code": "CT"
+  },
+  {
+    "id": 131938,
+    "name": "Gharghoda",
+    "state_code": "CT"
+  },
+  {
+    "id": 132048,
+    "name": "Gidam",
+    "state_code": "CT"
+  },
+  {
+    "id": 132186,
+    "name": "Jagdalpur",
+    "state_code": "CT"
+  },
+  {
+    "id": 132312,
+    "name": "Janjgir",
+    "state_code": "CT"
+  },
+  {
+    "id": 132240,
+    "name": "Janjgir-Champa",
+    "state_code": "CT"
+  },
+  {
+    "id": 132244,
+    "name": "Jashpur",
+    "state_code": "CT"
+  },
+  {
+    "id": 132245,
+    "name": "Jashpurnagar",
+    "state_code": "CT"
+  },
+  {
+    "id": 132318,
+    "name": "Junagarh",
+    "state_code": "CT"
+  },
+  {
+    "id": 132319,
+    "name": "Kabeerdham",
+    "state_code": "CT"
+  },
+  {
+    "id": 132704,
+    "name": "Kanker",
+    "state_code": "CT"
+  },
+  {
+    "id": 132421,
+    "name": "Katghora",
+    "state_code": "CT"
+  },
+  {
+    "id": 132433,
+    "name": "Kawardha",
+    "state_code": "CT"
+  },
+  {
+    "id": 132456,
+    "name": "Khairagarh",
+    "state_code": "CT"
+  },
+  {
+    "id": 132463,
+    "name": "Khamharia",
+    "state_code": "CT"
+  },
+  {
+    "id": 132480,
+    "name": "Kharod",
+    "state_code": "CT"
+  },
+  {
+    "id": 132481,
+    "name": "Kharsia",
+    "state_code": "CT"
+  },
+  {
+    "id": 132525,
+    "name": "Kirandul",
+    "state_code": "CT"
+  },
+  {
+    "id": 132565,
+    "name": "Kondagaon",
+    "state_code": "CT"
+  },
+  {
+    "id": 132581,
+    "name": "Korba",
+    "state_code": "CT"
+  },
+  {
+    "id": 132583,
+    "name": "Koria",
+    "state_code": "CT"
+  },
+  {
+    "id": 132612,
+    "name": "Kota",
+    "state_code": "CT"
+  },
+  {
+    "id": 132596,
+    "name": "Kotaparh",
+    "state_code": "CT"
+  },
+  {
+    "id": 132641,
+    "name": "Kumhari",
+    "state_code": "CT"
+  },
+  {
+    "id": 132661,
+    "name": "Kurud",
+    "state_code": "CT"
+  },
+  {
+    "id": 132777,
+    "name": "Lormi",
+    "state_code": "CT"
+  },
+  {
+    "id": 132827,
+    "name": "Mahasamund",
+    "state_code": "CT"
+  },
+  {
+    "id": 133031,
+    "name": "Mungeli",
+    "state_code": "CT"
+  },
+  {
+    "id": 133163,
+    "name": "Narayanpur",
+    "state_code": "CT"
+  },
+  {
+    "id": 133168,
+    "name": "Narharpur",
+    "state_code": "CT"
+  },
+  {
+    "id": 133346,
+    "name": "Pandaria",
+    "state_code": "CT"
+  },
+  {
+    "id": 133540,
+    "name": "Pandatarai",
+    "state_code": "CT"
+  },
+  {
+    "id": 133375,
+    "name": "Pasan",
+    "state_code": "CT"
+  },
+  {
+    "id": 133552,
+    "name": "Patan",
+    "state_code": "CT"
+  },
+  {
+    "id": 133379,
+    "name": "Pathalgaon",
+    "state_code": "CT"
+  },
+  {
+    "id": 133405,
+    "name": "Pendra",
+    "state_code": "CT"
+  },
+  {
+    "id": 133463,
+    "name": "Pithora",
+    "state_code": "CT"
+  },
+  {
+    "id": 133587,
+    "name": "Raigarh",
+    "state_code": "CT"
+  },
+  {
+    "id": 133590,
+    "name": "Raipur",
+    "state_code": "CT"
+  },
+  {
+    "id": 133668,
+    "name": "Raj Nandgaon",
+    "state_code": "CT"
+  },
+  {
+    "id": 133711,
+    "name": "Ramanuj Ganj",
+    "state_code": "CT"
+  },
+  {
+    "id": 133616,
+    "name": "Ratanpur",
+    "state_code": "CT"
+  },
+  {
+    "id": 133761,
+    "name": "Sakti",
+    "state_code": "CT"
+  },
+  {
+    "id": 133801,
+    "name": "Saraipali",
+    "state_code": "CT"
+  },
+  {
+    "id": 134077,
+    "name": "Sarangarh",
+    "state_code": "CT"
+  },
+  {
+    "id": 133845,
+    "name": "Seorinarayan",
+    "state_code": "CT"
+  },
+  {
+    "id": 133940,
+    "name": "Simga",
+    "state_code": "CT"
+  },
+  {
+    "id": 134051,
+    "name": "Surguja",
+    "state_code": "CT"
+  },
+  {
+    "id": 134099,
+    "name": "Takhatpur",
+    "state_code": "CT"
+  },
+  {
+    "id": 134273,
+    "name": "Umarkot",
+    "state_code": "CT"
+  },
+  {
+    "id": 134299,
+    "name": "Uttar Bastar Kanker",
+    "state_code": "CT"
+  },
+  {
+    "id": 134459,
+    "name": "Amli",
+    "state_code": "DH"
+  },
+  {
+    "id": 131639,
+    "name": "Dadra",
+    "state_code": "DH"
+  },
+  {
+    "id": 131640,
+    "name": "Dadra & Nagar Haveli",
+    "state_code": "DH"
+  },
+  {
+    "id": 131649,
+    "name": "Daman",
+    "state_code": "DH"
+  },
+  {
+    "id": 131779,
+    "name": "Diu",
+    "state_code": "DH"
+  },
+  {
+    "id": 133937,
+    "name": "Silvassa",
+    "state_code": "DH"
+  },
+  {
+    "id": 57655,
+    "name": "Alipur",
+    "state_code": "DL"
+  },
+  {
+    "id": 57909,
+    "name": "Bawana",
+    "state_code": "DL"
+  },
+  {
+    "id": 58171,
+    "name": "Central Delhi",
+    "state_code": "DL"
+  },
+  {
+    "id": 131679,
+    "name": "Delhi",
+    "state_code": "DL"
+  },
+  {
+    "id": 131687,
+    "name": "Deoli",
+    "state_code": "DL"
+  },
+  {
+    "id": 131821,
+    "name": "East Delhi",
+    "state_code": "DL"
+  },
+  {
+    "id": 132406,
+    "name": "Karol Bagh",
+    "state_code": "DL"
+  },
+  {
+    "id": 133126,
+    "name": "Najafgarh",
+    "state_code": "DL"
+  },
+  {
+    "id": 133269,
+    "name": "Nangloi Jat",
+    "state_code": "DL"
+  },
+  {
+    "id": 133165,
+    "name": "Narela",
+    "state_code": "DL"
+  },
+  {
+    "id": 133210,
+    "name": "New Delhi",
+    "state_code": "DL"
+  },
+  {
+    "id": 133234,
+    "name": "North Delhi",
+    "state_code": "DL"
+  },
+  {
+    "id": 133236,
+    "name": "North East Delhi",
+    "state_code": "DL"
+  },
+  {
+    "id": 133243,
+    "name": "North West Delhi",
+    "state_code": "DL"
+  },
+  {
+    "id": 133461,
+    "name": "Pitampura",
+    "state_code": "DL"
+  },
+  {
+    "id": 133645,
+    "name": "Rohini",
+    "state_code": "DL"
+  },
+  {
+    "id": 134007,
+    "name": "South Delhi",
+    "state_code": "DL"
+  },
+  {
+    "id": 134012,
+    "name": "South West Delhi",
+    "state_code": "DL"
+  },
+  {
+    "id": 134404,
+    "name": "West Delhi",
+    "state_code": "DL"
+  },
+  {
+    "id": 57638,
+    "name": "Aldona",
+    "state_code": "GA"
+  },
+  {
+    "id": 57727,
+    "name": "Arambol",
+    "state_code": "GA"
+  },
+  {
+    "id": 57795,
+    "name": "Baga",
+    "state_code": "GA"
+  },
+  {
+    "id": 57836,
+    "name": "Bambolim",
+    "state_code": "GA"
+  },
+  {
+    "id": 57845,
+    "name": "Bandora",
+    "state_code": "GA"
+  },
+  {
+    "id": 57932,
+    "name": "Benaulim",
+    "state_code": "GA"
+  },
+  {
+    "id": 58165,
+    "name": "Calangute",
+    "state_code": "GA"
+  },
+  {
+    "id": 58167,
+    "name": "Candolim",
+    "state_code": "GA"
+  },
+  {
+    "id": 58169,
+    "name": "Carapur",
+    "state_code": "GA"
+  },
+  {
+    "id": 58170,
+    "name": "Cavelossim",
+    "state_code": "GA"
+  },
+  {
+    "id": 131542,
+    "name": "Chicalim",
+    "state_code": "GA"
+  },
+  {
+    "id": 131559,
+    "name": "Chinchinim",
+    "state_code": "GA"
+  },
+  {
+    "id": 131622,
+    "name": "Colovale",
+    "state_code": "GA"
+  },
+  {
+    "id": 131623,
+    "name": "Colva",
+    "state_code": "GA"
+  },
+  {
+    "id": 131625,
+    "name": "Cortalim",
+    "state_code": "GA"
+  },
+  {
+    "id": 131630,
+    "name": "Cuncolim",
+    "state_code": "GA"
+  },
+  {
+    "id": 131631,
+    "name": "Curchorem",
+    "state_code": "GA"
+  },
+  {
+    "id": 131632,
+    "name": "Curti",
+    "state_code": "GA"
+  },
+  {
+    "id": 131672,
+    "name": "Davorlim",
+    "state_code": "GA"
+  },
+  {
+    "id": 131764,
+    "name": "Dicholi",
+    "state_code": "GA"
+  },
+  {
+    "id": 131960,
+    "name": "Goa Velha",
+    "state_code": "GA"
+  },
+  {
+    "id": 132015,
+    "name": "Guirim",
+    "state_code": "GA"
+  },
+  {
+    "id": 132297,
+    "name": "Jua",
+    "state_code": "GA"
+  },
+  {
+    "id": 132705,
+    "name": "Kankon",
+    "state_code": "GA"
+  },
+  {
+    "id": 132811,
+    "name": "Madgaon",
+    "state_code": "GA"
+  },
+  {
+    "id": 133086,
+    "name": "Mapuca",
+    "state_code": "GA"
+  },
+  {
+    "id": 132997,
+    "name": "Morjim",
+    "state_code": "GA"
+  },
+  {
+    "id": 132998,
+    "name": "Mormugao",
+    "state_code": "GA"
+  },
+  {
+    "id": 133185,
+    "name": "Navelim",
+    "state_code": "GA"
+  },
+  {
+    "id": 133238,
+    "name": "North Goa",
+    "state_code": "GA"
+  },
+  {
+    "id": 133330,
+    "name": "Palle",
+    "state_code": "GA"
+  },
+  {
+    "id": 133342,
+    "name": "Panaji",
+    "state_code": "GA"
+  },
+  {
+    "id": 133422,
+    "name": "Pernem",
+    "state_code": "GA"
+  },
+  {
+    "id": 133471,
+    "name": "Ponda",
+    "state_code": "GA"
+  },
+  {
+    "id": 133572,
+    "name": "Quepem",
+    "state_code": "GA"
+  },
+  {
+    "id": 133573,
+    "name": "Queula",
+    "state_code": "GA"
+  },
+  {
+    "id": 133585,
+    "name": "Raia",
+    "state_code": "GA"
+  },
+  {
+    "id": 133764,
+    "name": "Saligao",
+    "state_code": "GA"
+  },
+  {
+    "id": 133777,
+    "name": "Sancoale",
+    "state_code": "GA"
+  },
+  {
+    "id": 133786,
+    "name": "Sanguem",
+    "state_code": "GA"
+  },
+  {
+    "id": 133791,
+    "name": "Sanquelim",
+    "state_code": "GA"
+  },
+  {
+    "id": 133795,
+    "name": "Sanvordem",
+    "state_code": "GA"
+  },
+  {
+    "id": 133850,
+    "name": "Serula",
+    "state_code": "GA"
+  },
+  {
+    "id": 133987,
+    "name": "Solim",
+    "state_code": "GA"
+  },
+  {
+    "id": 134010,
+    "name": "South Goa",
+    "state_code": "GA"
+  },
+  {
+    "id": 134101,
+    "name": "Taleigao",
+    "state_code": "GA"
+  },
+  {
+    "id": 134311,
+    "name": "Vagator",
+    "state_code": "GA"
+  },
+  {
+    "id": 134321,
+    "name": "Valpoy",
+    "state_code": "GA"
+  },
+  {
+    "id": 134329,
+    "name": "Varca",
+    "state_code": "GA"
+  },
+  {
+    "id": 134333,
+    "name": "Vasco da Gama",
+    "state_code": "GA"
+  },
+  {
+    "id": 57588,
+    "name": "Abrama",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57591,
+    "name": "Adalaj",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147572,
+    "name": "Agol",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57606,
+    "name": "Ahmedabad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57608,
+    "name": "Ahwa",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147573,
+    "name": "Akrund",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57683,
+    "name": "Amod",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57685,
+    "name": "Amreli",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57688,
+    "name": "Amroli",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57695,
+    "name": "Anand",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57709,
+    "name": "Anjar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57710,
+    "name": "Ankleshwar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 58104,
+    "name": "Babra",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142125,
+    "name": "Bagasara",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57799,
+    "name": "Bagasra",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147575,
+    "name": "Bakharla",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147576,
+    "name": "Balagam",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147577,
+    "name": "Balasinor",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147578,
+    "name": "Balisana",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147579,
+    "name": "Bamanbore",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57858,
+    "name": "Banas Kantha",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147580,
+    "name": "Bandia",
+    "state_code": "GJ"
+  },
+  {
+    "id": 58135,
+    "name": "Bantva",
+    "state_code": "GJ"
+  },
+  {
+    "id": 58140,
+    "name": "Bardoli",
+    "state_code": "GJ"
+  },
+  {
+    "id": 153924,
+    "name": "Bavla",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57911,
+    "name": "Bedi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57948,
+    "name": "Bhachau",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147581,
+    "name": "Bhadran",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147582,
+    "name": "Bhandu",
+    "state_code": "GJ"
+  },
+  {
+    "id": 58014,
+    "name": "Bhanvad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57967,
+    "name": "Bharuch",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147583,
+    "name": "Bhatha",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57972,
+    "name": "Bhavnagar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 58017,
+    "name": "Bhayavadar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147584,
+    "name": "Bhildi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147585,
+    "name": "Bhojpur Dharampur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 58002,
+    "name": "Bhuj",
+    "state_code": "GJ"
+  },
+  {
+    "id": 58045,
+    "name": "Bilimora",
+    "state_code": "GJ"
+  },
+  {
+    "id": 58046,
+    "name": "Bilkha",
+    "state_code": "GJ"
+  },
+  {
+    "id": 58084,
+    "name": "Borsad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 58085,
+    "name": "Botad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 58174,
+    "name": "Chaklasi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 58180,
+    "name": "Chalala",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147586,
+    "name": "Chaloda",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147587,
+    "name": "Champaner",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131595,
+    "name": "Chanasma",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131529,
+    "name": "Chhala",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131535,
+    "name": "Chhota Udepur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131548,
+    "name": "Chikhli",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131582,
+    "name": "Chotila",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147588,
+    "name": "Chuda",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147589,
+    "name": "Dabhoda",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131635,
+    "name": "Dabhoi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131642,
+    "name": "Dahegam",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142126,
+    "name": "Dahod",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131808,
+    "name": "Dakor",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131809,
+    "name": "Damnagar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147590,
+    "name": "Dandi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142127,
+    "name": "Dangs (India)",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147591,
+    "name": "Danta",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131673,
+    "name": "Dayapar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131680,
+    "name": "Delvada",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142128,
+    "name": "Delwada",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147592,
+    "name": "Detroj",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131704,
+    "name": "Devbhumi Dwarka",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131705,
+    "name": "Devgadh Bariya",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131716,
+    "name": "Dhandhuka",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131717,
+    "name": "Dhanera",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147593,
+    "name": "Dhansura",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131719,
+    "name": "Dharampur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147594,
+    "name": "Dharasana",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131755,
+    "name": "Dhari",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147595,
+    "name": "Dhasa",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131738,
+    "name": "Dhola",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147596,
+    "name": "Dholera",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131739,
+    "name": "Dholka",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131741,
+    "name": "Dhoraji",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131743,
+    "name": "Dhrangadhra",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131742,
+    "name": "Dhrol",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131747,
+    "name": "Dhuwaran",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131817,
+    "name": "Disa",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131782,
+    "name": "Dohad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147597,
+    "name": "Dumkhal",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131800,
+    "name": "Dungarpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131803,
+    "name": "Dwarka",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131888,
+    "name": "Gadhada",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131899,
+    "name": "Gandevi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132046,
+    "name": "Gandhidham",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131900,
+    "name": "Gandhinagar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131925,
+    "name": "Gariadhar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147598,
+    "name": "Ghodasar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131944,
+    "name": "Ghogha",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131958,
+    "name": "Gir Somnath",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131964,
+    "name": "Godhra",
+    "state_code": "GJ"
+  },
+  {
+    "id": 131982,
+    "name": "Gondal",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147599,
+    "name": "Gorwa",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147600,
+    "name": "Halenda",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132139,
+    "name": "Halol",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132060,
+    "name": "Halvad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132065,
+    "name": "Hansot",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132143,
+    "name": "Harij",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147601,
+    "name": "Harsol",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147602,
+    "name": "Hathuran",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132096,
+    "name": "Himatnagar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147603,
+    "name": "Idar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147604,
+    "name": "Jakhau",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142129,
+    "name": "Jalalpore",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132219,
+    "name": "Jalalpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147605,
+    "name": "Jalia",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147606,
+    "name": "Jambuda",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132226,
+    "name": "Jambusar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132230,
+    "name": "Jamnagar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147607,
+    "name": "Jarod",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132243,
+    "name": "Jasdan",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147608,
+    "name": "Jetalpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132261,
+    "name": "Jetalsar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132262,
+    "name": "Jetpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147609,
+    "name": "Jetpur (Navagadh)",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147610,
+    "name": "Jhalod",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132272,
+    "name": "Jhulasan",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132285,
+    "name": "Jodhpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147611,
+    "name": "Jodhpur (Ahmedabad)",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142130,
+    "name": "Jodia",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132287,
+    "name": "Jodiya Bandar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132317,
+    "name": "Junagadh",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132321,
+    "name": "Kachchh",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147612,
+    "name": "Kachholi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132327,
+    "name": "Kadi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132329,
+    "name": "Kadod",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132689,
+    "name": "Kalavad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132682,
+    "name": "Kalol",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132698,
+    "name": "Kandla",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147613,
+    "name": "Kandla port",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132708,
+    "name": "Kanodar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132390,
+    "name": "Kapadvanj",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132394,
+    "name": "Karamsad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147614,
+    "name": "Kariana",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147615,
+    "name": "Karjan",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132723,
+    "name": "Kathor",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132425,
+    "name": "Katpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132434,
+    "name": "Kawant",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147616,
+    "name": "Kayavarohan",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147617,
+    "name": "Kerwada",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132446,
+    "name": "Keshod",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142132,
+    "name": "Khambhalia",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132462,
+    "name": "Khambhat",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147618,
+    "name": "Khavda",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132488,
+    "name": "Kheda",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132489,
+    "name": "Khedbrahma",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147619,
+    "name": "Khedoi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147620,
+    "name": "Kherali",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132494,
+    "name": "Kheralu",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132547,
+    "name": "Kodinar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132588,
+    "name": "Kosamba",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147621,
+    "name": "Kothara",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147622,
+    "name": "Kotharia",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147623,
+    "name": "Kukarmunda",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147624,
+    "name": "Kukma",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132647,
+    "name": "Kundla",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142133,
+    "name": "Kutch district",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132670,
+    "name": "Kutiyana",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147628,
+    "name": "Ladol",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147625,
+    "name": "Lakhpat",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132747,
+    "name": "Lakhtar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132797,
+    "name": "Lalpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147626,
+    "name": "Langhnaj",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132802,
+    "name": "Lathi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132764,
+    "name": "Limbdi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147627,
+    "name": "Limkheda",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132804,
+    "name": "Lunavada",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147629,
+    "name": "Madhavpur Ghed",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147630,
+    "name": "Madhi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132831,
+    "name": "Mahemdavad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132834,
+    "name": "Mahesana",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147631,
+    "name": "Mahisa",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132841,
+    "name": "Mahudha",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147632,
+    "name": "Mahuva",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147633,
+    "name": "Mahuva (Surat)",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133068,
+    "name": "Malpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133085,
+    "name": "Manavadar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133073,
+    "name": "Mandal",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133076,
+    "name": "Mandvi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142134,
+    "name": "Mandvi (Surat)",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133077,
+    "name": "Mangrol",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147634,
+    "name": "Mangrol (Junagadh)",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133081,
+    "name": "Mansa",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132960,
+    "name": "Meghraj",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142135,
+    "name": "Mehsana",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132966,
+    "name": "Mendarda",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147635,
+    "name": "Mithapur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132978,
+    "name": "Modasa",
+    "state_code": "GJ"
+  },
+  {
+    "id": 132993,
+    "name": "Morbi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142136,
+    "name": "Morva (Hadaf)",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133000,
+    "name": "Morwa",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133029,
+    "name": "Mundra",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133106,
+    "name": "Nadiad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147637,
+    "name": "Nagwa",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147638,
+    "name": "Naldhara",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133133,
+    "name": "Naliya",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147639,
+    "name": "Nargol",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133169,
+    "name": "Narmada",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133170,
+    "name": "Naroda",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133187,
+    "name": "Navsari",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147640,
+    "name": "Nikora",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147641,
+    "name": "Nizar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147642,
+    "name": "Odadar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133297,
+    "name": "Okha",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133298,
+    "name": "Olpad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133313,
+    "name": "Paddhari",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133315,
+    "name": "Padra",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133526,
+    "name": "Palanpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147643,
+    "name": "Palanswa",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133532,
+    "name": "Palitana",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133533,
+    "name": "Paliyad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147645,
+    "name": "Palsana",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133536,
+    "name": "Panch Mahals",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142137,
+    "name": "Panchmahal district",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133548,
+    "name": "Pardi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133362,
+    "name": "Parnera",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133376,
+    "name": "Patan",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142138,
+    "name": "Pavi Jetpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133429,
+    "name": "Petlad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147646,
+    "name": "Pipavav",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147647,
+    "name": "Piplod",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133480,
+    "name": "Porbandar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147648,
+    "name": "Prabhas Patan",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147649,
+    "name": "Prantij",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133657,
+    "name": "Radhanpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133679,
+    "name": "Rajkot",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133682,
+    "name": "Rajpipla",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133684,
+    "name": "Rajula",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133718,
+    "name": "Ranavav",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147650,
+    "name": "Ranpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133722,
+    "name": "Rapar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147651,
+    "name": "Reha",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133643,
+    "name": "Roha",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133739,
+    "name": "Sabar Kantha",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133742,
+    "name": "Sachin",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133766,
+    "name": "Salaya",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147652,
+    "name": "Samakhiali",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134069,
+    "name": "Sanand",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133790,
+    "name": "Sankheda",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147653,
+    "name": "Sarbhon",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147654,
+    "name": "Sardoi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133808,
+    "name": "Sarkhej",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147655,
+    "name": "Sathamba",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133831,
+    "name": "Savarkundla",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147656,
+    "name": "Savli",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134085,
+    "name": "Sayla",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133900,
+    "name": "Shahpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133882,
+    "name": "Shivrajpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142139,
+    "name": "Siddhpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133925,
+    "name": "Sihor",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133932,
+    "name": "Sikka",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133954,
+    "name": "Sinor",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133984,
+    "name": "Sojitra",
+    "state_code": "GJ"
+  },
+  {
+    "id": 133995,
+    "name": "Songadh",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147657,
+    "name": "Supedi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134096,
+    "name": "Surat",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134050,
+    "name": "Surendranagar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147658,
+    "name": "Sutrapada",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134107,
+    "name": "Talaja",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134112,
+    "name": "Tankara",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134114,
+    "name": "Tapi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134164,
+    "name": "Than",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142140,
+    "name": "Thangadh",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134144,
+    "name": "Tharad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134168,
+    "name": "Thasra",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134145,
+    "name": "The Dangs",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147659,
+    "name": "Umarpada",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134277,
+    "name": "Umrala",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134275,
+    "name": "Umreth",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134278,
+    "name": "Un",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134280,
+    "name": "Una",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134284,
+    "name": "Unjha",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134286,
+    "name": "Upleta",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134297,
+    "name": "Utran",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147660,
+    "name": "Vadgam",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134309,
+    "name": "Vadnagar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134310,
+    "name": "Vadodara",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134381,
+    "name": "Vaghodia",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147661,
+    "name": "Vaghodia INA",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134318,
+    "name": "Vallabh Vidyanagar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142141,
+    "name": "Vallabhipur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134322,
+    "name": "Valsad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147662,
+    "name": "Vanala",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142142,
+    "name": "Vansda",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147663,
+    "name": "Vanthli",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134326,
+    "name": "Vapi",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134331,
+    "name": "Vartej",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134332,
+    "name": "Vasa",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147664,
+    "name": "Vasavad",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142143,
+    "name": "Vaso",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147665,
+    "name": "Vataman",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134339,
+    "name": "Vejalpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134349,
+    "name": "Veraval",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134357,
+    "name": "Vijapur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142144,
+    "name": "Vinchhiya",
+    "state_code": "GJ"
+  },
+  {
+    "id": 147666,
+    "name": "Viramgam",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134365,
+    "name": "Virpur",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134387,
+    "name": "Visavadar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134371,
+    "name": "Visnagar",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134378,
+    "name": "Vyara",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142145,
+    "name": "Wadhai",
+    "state_code": "GJ"
+  },
+  {
+    "id": 142146,
+    "name": "Wadhwan",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134389,
+    "name": "Waghai",
+    "state_code": "GJ"
+  },
+  {
+    "id": 134416,
+    "name": "Wankaner",
+    "state_code": "GJ"
+  },
+  {
+    "id": 57675,
+    "name": "Ambala",
+    "state_code": "HR"
+  },
+  {
+    "id": 134464,
+    "name": "Asandh",
+    "state_code": "HR"
+  },
+  {
+    "id": 57756,
+    "name": "Ateli Mandi",
+    "state_code": "HR"
+  },
+  {
+    "id": 57810,
+    "name": "Bahadurgarh",
+    "state_code": "HR"
+  },
+  {
+    "id": 57861,
+    "name": "Bara Uchana",
+    "state_code": "HR"
+  },
+  {
+    "id": 57890,
+    "name": "Barwala",
+    "state_code": "HR"
+  },
+  {
+    "id": 58152,
+    "name": "Bawal",
+    "state_code": "HR"
+  },
+  {
+    "id": 57937,
+    "name": "Beri Khas",
+    "state_code": "HR"
+  },
+  {
+    "id": 57988,
+    "name": "Bhiwani",
+    "state_code": "HR"
+  },
+  {
+    "id": 58054,
+    "name": "Bilaspur",
+    "state_code": "HR"
+  },
+  {
+    "id": 58164,
+    "name": "Buriya",
+    "state_code": "HR"
+  },
+  {
+    "id": 58200,
+    "name": "Charkhi Dadri",
+    "state_code": "HR"
+  },
+  {
+    "id": 131528,
+    "name": "Chhachhrauli",
+    "state_code": "HR"
+  },
+  {
+    "id": 131638,
+    "name": "Dabwali",
+    "state_code": "HR"
+  },
+  {
+    "id": 131757,
+    "name": "Dharuhera",
+    "state_code": "HR"
+  },
+  {
+    "id": 131831,
+    "name": "Ellenabad",
+    "state_code": "HR"
+  },
+  {
+    "id": 131853,
+    "name": "Faridabad",
+    "state_code": "HR"
+  },
+  {
+    "id": 131856,
+    "name": "Farrukhnagar",
+    "state_code": "HR"
+  },
+  {
+    "id": 131872,
+    "name": "Fatehabad",
+    "state_code": "HR"
+  },
+  {
+    "id": 131882,
+    "name": "Firozpur Jhirka",
+    "state_code": "HR"
+  },
+  {
+    "id": 131937,
+    "name": "Gharaunda",
+    "state_code": "HR"
+  },
+  {
+    "id": 131968,
+    "name": "Gohana",
+    "state_code": "HR"
+  },
+  {
+    "id": 131991,
+    "name": "Gorakhpur",
+    "state_code": "HR"
+  },
+  {
+    "id": 132032,
+    "name": "Gurgaon",
+    "state_code": "HR"
+  },
+  {
+    "id": 132141,
+    "name": "Hansi",
+    "state_code": "HR"
+  },
+  {
+    "id": 132084,
+    "name": "Hasanpur",
+    "state_code": "HR"
+  },
+  {
+    "id": 132106,
+    "name": "Hisar",
+    "state_code": "HR"
+  },
+  {
+    "id": 132109,
+    "name": "Hodal",
+    "state_code": "HR"
+  },
+  {
+    "id": 132163,
+    "name": "Inda Chhoi",
+    "state_code": "HR"
+  },
+  {
+    "id": 132167,
+    "name": "Indri",
+    "state_code": "HR"
+  },
+  {
+    "id": 132194,
+    "name": "Jagadhri",
+    "state_code": "HR"
+  },
+  {
+    "id": 132305,
+    "name": "Jakhal",
+    "state_code": "HR"
+  },
+  {
+    "id": 132266,
+    "name": "Jhajjar",
+    "state_code": "HR"
+  },
+  {
+    "id": 132315,
+    "name": "Jind",
+    "state_code": "HR"
+  },
+  {
+    "id": 132340,
+    "name": "Kaithal",
+    "state_code": "HR"
+  },
+  {
+    "id": 132360,
+    "name": "Kalanaur",
+    "state_code": "HR"
+  },
+  {
+    "id": 132688,
+    "name": "Kalanwali",
+    "state_code": "HR"
+  },
+  {
+    "id": 132389,
+    "name": "Kanina Khas",
+    "state_code": "HR"
+  },
+  {
+    "id": 132405,
+    "name": "Karnal",
+    "state_code": "HR"
+  },
+  {
+    "id": 132478,
+    "name": "Kharkhauda",
+    "state_code": "HR"
+  },
+  {
+    "id": 132493,
+    "name": "Kheri Sampla",
+    "state_code": "HR"
+  },
+  {
+    "id": 132662,
+    "name": "Kurukshetra",
+    "state_code": "HR"
+  },
+  {
+    "id": 132789,
+    "name": "Ladwa",
+    "state_code": "HR"
+  },
+  {
+    "id": 132772,
+    "name": "Loharu",
+    "state_code": "HR"
+  },
+  {
+    "id": 132825,
+    "name": "Maham",
+    "state_code": "HR"
+  },
+  {
+    "id": 132832,
+    "name": "Mahendragarh",
+    "state_code": "HR"
+  },
+  {
+    "id": 132892,
+    "name": "Mandholi Kalan",
+    "state_code": "HR"
+  },
+  {
+    "id": 133047,
+    "name": "Mustafabad",
+    "state_code": "HR"
+  },
+  {
+    "id": 133176,
+    "name": "Narayangarh",
+    "state_code": "HR"
+  },
+  {
+    "id": 133272,
+    "name": "Narnaul",
+    "state_code": "HR"
+  },
+  {
+    "id": 133273,
+    "name": "Narnaund",
+    "state_code": "HR"
+  },
+  {
+    "id": 133175,
+    "name": "Narwana",
+    "state_code": "HR"
+  },
+  {
+    "id": 133286,
+    "name": "Nilokheri",
+    "state_code": "HR"
+  },
+  {
+    "id": 133290,
+    "name": "Nuh",
+    "state_code": "HR"
+  },
+  {
+    "id": 133337,
+    "name": "Palwal",
+    "state_code": "HR"
+  },
+  {
+    "id": 133345,
+    "name": "Panchkula",
+    "state_code": "HR"
+  },
+  {
+    "id": 133350,
+    "name": "Panipat",
+    "state_code": "HR"
+  },
+  {
+    "id": 133378,
+    "name": "Pataudi",
+    "state_code": "HR"
+  },
+  {
+    "id": 133403,
+    "name": "Pehowa",
+    "state_code": "HR"
+  },
+  {
+    "id": 133451,
+    "name": "Pinjaur",
+    "state_code": "HR"
+  },
+  {
+    "id": 133568,
+    "name": "Punahana",
+    "state_code": "HR"
+  },
+  {
+    "id": 133567,
+    "name": "Pundri",
+    "state_code": "HR"
+  },
+  {
+    "id": 133579,
+    "name": "Radaur",
+    "state_code": "HR"
+  },
+  {
+    "id": 133715,
+    "name": "Rania",
+    "state_code": "HR"
+  },
+  {
+    "id": 133617,
+    "name": "Ratia",
+    "state_code": "HR"
+  },
+  {
+    "id": 133635,
+    "name": "Rewari",
+    "state_code": "HR"
+  },
+  {
+    "id": 133647,
+    "name": "Rohtak",
+    "state_code": "HR"
+  },
+  {
+    "id": 133746,
+    "name": "Safidon",
+    "state_code": "HR"
+  },
+  {
+    "id": 133774,
+    "name": "Samalkha",
+    "state_code": "HR"
+  },
+  {
+    "id": 133891,
+    "name": "Shadipur Julana",
+    "state_code": "HR"
+  },
+  {
+    "id": 133906,
+    "name": "Shahabad",
+    "state_code": "HR"
+  },
+  {
+    "id": 133961,
+    "name": "Sirsa",
+    "state_code": "HR"
+  },
+  {
+    "id": 133980,
+    "name": "Sohna",
+    "state_code": "HR"
+  },
+  {
+    "id": 133999,
+    "name": "Sonipat",
+    "state_code": "HR"
+  },
+  {
+    "id": 134238,
+    "name": "Taoru",
+    "state_code": "HR"
+  },
+  {
+    "id": 134167,
+    "name": "Thanesar",
+    "state_code": "HR"
+  },
+  {
+    "id": 134206,
+    "name": "Tohana",
+    "state_code": "HR"
+  },
+  {
+    "id": 134211,
+    "name": "Tosham",
+    "state_code": "HR"
+  },
+  {
+    "id": 134265,
+    "name": "Uklana",
+    "state_code": "HR"
+  },
+  {
+    "id": 134422,
+    "name": "Yamunanagar",
+    "state_code": "HR"
+  },
+  {
+    "id": 57736,
+    "name": "Arki",
+    "state_code": "HP"
+  },
+  {
+    "id": 57789,
+    "name": "Baddi",
+    "state_code": "HP"
+  },
+  {
+    "id": 57853,
+    "name": "Banjar",
+    "state_code": "HP"
+  },
+  {
+    "id": 58041,
+    "name": "Bilaspur",
+    "state_code": "HP"
+  },
+  {
+    "id": 58181,
+    "name": "Chamba",
+    "state_code": "HP"
+  },
+  {
+    "id": 131512,
+    "name": "Chaupal",
+    "state_code": "HP"
+  },
+  {
+    "id": 131583,
+    "name": "Chowari",
+    "state_code": "HP"
+  },
+  {
+    "id": 131587,
+    "name": "Chuari Khas",
+    "state_code": "HP"
+  },
+  {
+    "id": 131641,
+    "name": "Dagshai",
+    "state_code": "HP"
+  },
+  {
+    "id": 131645,
+    "name": "Dalhousie",
+    "state_code": "HP"
+  },
+  {
+    "id": 131665,
+    "name": "Daulatpur",
+    "state_code": "HP"
+  },
+  {
+    "id": 131694,
+    "name": "Dera Gopipur",
+    "state_code": "HP"
+  },
+  {
+    "id": 131721,
+    "name": "Dharamsala",
+    "state_code": "HP"
+  },
+  {
+    "id": 131891,
+    "name": "Gagret",
+    "state_code": "HP"
+  },
+  {
+    "id": 131949,
+    "name": "Ghumarwin",
+    "state_code": "HP"
+  },
+  {
+    "id": 132063,
+    "name": "Hamirpur",
+    "state_code": "HP"
+  },
+  {
+    "id": 132255,
+    "name": "Jawala Mukhi",
+    "state_code": "HP"
+  },
+  {
+    "id": 132289,
+    "name": "Jogindarnagar",
+    "state_code": "HP"
+  },
+  {
+    "id": 132298,
+    "name": "Jubbal",
+    "state_code": "HP"
+  },
+  {
+    "id": 132302,
+    "name": "Jutogh",
+    "state_code": "HP"
+  },
+  {
+    "id": 132681,
+    "name": "Kalka",
+    "state_code": "HP"
+  },
+  {
+    "id": 132701,
+    "name": "Kangar",
+    "state_code": "HP"
+  },
+  {
+    "id": 132702,
+    "name": "Kangra",
+    "state_code": "HP"
+  },
+  {
+    "id": 132416,
+    "name": "Kasauli",
+    "state_code": "HP"
+  },
+  {
+    "id": 132523,
+    "name": "Kinnaur",
+    "state_code": "HP"
+  },
+  {
+    "id": 132601,
+    "name": "Kotkhai",
+    "state_code": "HP"
+  },
+  {
+    "id": 132602,
+    "name": "Kotla",
+    "state_code": "HP"
+  },
+  {
+    "id": 132636,
+    "name": "Kulu",
+    "state_code": "HP"
+  },
+  {
+    "id": 132675,
+    "name": "Kyelang",
+    "state_code": "HP"
+  },
+  {
+    "id": 132791,
+    "name": "Lahul and Spiti",
+    "state_code": "HP"
+  },
+  {
+    "id": 132929,
+    "name": "Manali",
+    "state_code": "HP"
+  },
+  {
+    "id": 132893,
+    "name": "Mandi",
+    "state_code": "HP"
+  },
+  {
+    "id": 133251,
+    "name": "Nadaun",
+    "state_code": "HP"
+  },
+  {
+    "id": 133113,
+    "name": "Nagar",
+    "state_code": "HP"
+  },
+  {
+    "id": 133118,
+    "name": "Nagrota",
+    "state_code": "HP"
+  },
+  {
+    "id": 133261,
+    "name": "Nahan",
+    "state_code": "HP"
+  },
+  {
+    "id": 133263,
+    "name": "Nalagarh",
+    "state_code": "HP"
+  },
+  {
+    "id": 133525,
+    "name": "Palampur",
+    "state_code": "HP"
+  },
+  {
+    "id": 133539,
+    "name": "Pandoh",
+    "state_code": "HP"
+  },
+  {
+    "id": 133544,
+    "name": "Paonta Sahib",
+    "state_code": "HP"
+  },
+  {
+    "id": 133369,
+    "name": "Parwanoo",
+    "state_code": "HP"
+  },
+  {
+    "id": 133676,
+    "name": "Rajgarh",
+    "state_code": "HP"
+  },
+  {
+    "id": 133706,
+    "name": "Rampur",
+    "state_code": "HP"
+  },
+  {
+    "id": 133646,
+    "name": "Rohru",
+    "state_code": "HP"
+  },
+  {
+    "id": 133741,
+    "name": "Sabathu",
+    "state_code": "HP"
+  },
+  {
+    "id": 133794,
+    "name": "Santokhgarh",
+    "state_code": "HP"
+  },
+  {
+    "id": 133811,
+    "name": "Sarahan",
+    "state_code": "HP"
+  },
+  {
+    "id": 133807,
+    "name": "Sarka Ghat",
+    "state_code": "HP"
+  },
+  {
+    "id": 133841,
+    "name": "Seoni",
+    "state_code": "HP"
+  },
+  {
+    "id": 133871,
+    "name": "Shimla",
+    "state_code": "HP"
+  },
+  {
+    "id": 133957,
+    "name": "Sirmaur",
+    "state_code": "HP"
+  },
+  {
+    "id": 133985,
+    "name": "Solan",
+    "state_code": "HP"
+  },
+  {
+    "id": 134045,
+    "name": "Sundarnagar",
+    "state_code": "HP"
+  },
+  {
+    "id": 134149,
+    "name": "Theog",
+    "state_code": "HP"
+  },
+  {
+    "id": 134246,
+    "name": "Tira Sujanpur",
+    "state_code": "HP"
+  },
+  {
+    "id": 134279,
+    "name": "Una",
+    "state_code": "HP"
+  },
+  {
+    "id": 134435,
+    "name": "Yol",
+    "state_code": "HP"
+  },
+  {
+    "id": 57622,
+    "name": "Akhnur",
+    "state_code": "JK"
+  },
+  {
+    "id": 57699,
+    "name": "Anantnag",
+    "state_code": "JK"
+  },
+  {
+    "id": 57774,
+    "name": "Awantipur",
+    "state_code": "JK"
+  },
+  {
+    "id": 57790,
+    "name": "Badgam",
+    "state_code": "JK"
+  },
+  {
+    "id": 57843,
+    "name": "Bandipore",
+    "state_code": "JK"
+  },
+  {
+    "id": 57852,
+    "name": "Banihal",
+    "state_code": "JK"
+  },
+  {
+    "id": 58139,
+    "name": "Baramula",
+    "state_code": "JK"
+  },
+  {
+    "id": 57905,
+    "name": "Batoti",
+    "state_code": "JK"
+  },
+  {
+    "id": 57949,
+    "name": "Bhadarwah",
+    "state_code": "JK"
+  },
+  {
+    "id": 58033,
+    "name": "Bijbehara",
+    "state_code": "JK"
+  },
+  {
+    "id": 58065,
+    "name": "Bishnah",
+    "state_code": "JK"
+  },
+  {
+    "id": 131781,
+    "name": "Doda",
+    "state_code": "JK"
+  },
+  {
+    "id": 131898,
+    "name": "Ganderbal",
+    "state_code": "JK"
+  },
+  {
+    "id": 131942,
+    "name": "Gho Brahmanan de",
+    "state_code": "JK"
+  },
+  {
+    "id": 132135,
+    "name": "Hajan",
+    "state_code": "JK"
+  },
+  {
+    "id": 132105,
+    "name": "Hiranagar",
+    "state_code": "JK"
+  },
+  {
+    "id": 132229,
+    "name": "Jammu",
+    "state_code": "JK"
+  },
+  {
+    "id": 132253,
+    "name": "Jaurian",
+    "state_code": "JK"
+  },
+  {
+    "id": 132422,
+    "name": "Kathua",
+    "state_code": "JK"
+  },
+  {
+    "id": 132427,
+    "name": "Katra",
+    "state_code": "JK"
+  },
+  {
+    "id": 132485,
+    "name": "Khaur",
+    "state_code": "JK"
+  },
+  {
+    "id": 132533,
+    "name": "Kishtwar",
+    "state_code": "JK"
+  },
+  {
+    "id": 132735,
+    "name": "Kud",
+    "state_code": "JK"
+  },
+  {
+    "id": 132633,
+    "name": "Kulgam",
+    "state_code": "JK"
+  },
+  {
+    "id": 132654,
+    "name": "Kupwara",
+    "state_code": "JK"
+  },
+  {
+    "id": 132740,
+    "name": "Ladakh",
+    "state_code": "JK"
+  },
+  {
+    "id": 133061,
+    "name": "Magam",
+    "state_code": "JK"
+  },
+  {
+    "id": 133193,
+    "name": "Nawanshahr",
+    "state_code": "JK"
+  },
+  {
+    "id": 133244,
+    "name": "Noria",
+    "state_code": "JK"
+  },
+  {
+    "id": 133310,
+    "name": "Padam",
+    "state_code": "JK"
+  },
+  {
+    "id": 133317,
+    "name": "Pahlgam",
+    "state_code": "JK"
+  },
+  {
+    "id": 133363,
+    "name": "Parol",
+    "state_code": "JK"
+  },
+  {
+    "id": 133388,
+    "name": "Pattan",
+    "state_code": "JK"
+  },
+  {
+    "id": 133501,
+    "name": "Pulwama",
+    "state_code": "JK"
+  },
+  {
+    "id": 133503,
+    "name": "Punch",
+    "state_code": "JK"
+  },
+  {
+    "id": 133576,
+    "name": "Qazigund",
+    "state_code": "JK"
+  },
+  {
+    "id": 133593,
+    "name": "Rajaori",
+    "state_code": "JK"
+  },
+  {
+    "id": 133673,
+    "name": "Rajauri",
+    "state_code": "JK"
+  },
+  {
+    "id": 133601,
+    "name": "Ramban",
+    "state_code": "JK"
+  },
+  {
+    "id": 133698,
+    "name": "Ramgarh",
+    "state_code": "JK"
+  },
+  {
+    "id": 133702,
+    "name": "Ramnagar",
+    "state_code": "JK"
+  },
+  {
+    "id": 133640,
+    "name": "Riasi",
+    "state_code": "JK"
+  },
+  {
+    "id": 133768,
+    "name": "Samba",
+    "state_code": "JK"
+  },
+  {
+    "id": 133889,
+    "name": "Shupiyan",
+    "state_code": "JK"
+  },
+  {
+    "id": 134000,
+    "name": "Sopur",
+    "state_code": "JK"
+  },
+  {
+    "id": 134016,
+    "name": "Soyibug",
+    "state_code": "JK"
+  },
+  {
+    "id": 134020,
+    "name": "Srinagar",
+    "state_code": "JK"
+  },
+  {
+    "id": 134043,
+    "name": "Sumbal",
+    "state_code": "JK"
+  },
+  {
+    "id": 134139,
+    "name": "Thang",
+    "state_code": "JK"
+  },
+  {
+    "id": 134141,
+    "name": "Thanna Mandi",
+    "state_code": "JK"
+  },
+  {
+    "id": 134213,
+    "name": "Tral",
+    "state_code": "JK"
+  },
+  {
+    "id": 134214,
+    "name": "Tsrar Sharif",
+    "state_code": "JK"
+  },
+  {
+    "id": 134257,
+    "name": "Udhampur",
+    "state_code": "JK"
+  },
+  {
+    "id": 134293,
+    "name": "Uri",
+    "state_code": "JK"
+  },
+  {
+    "id": 57802,
+    "name": "Bagra",
+    "state_code": "JH"
+  },
+  {
+    "id": 57880,
+    "name": "Barka Kana",
+    "state_code": "JH"
+  },
+  {
+    "id": 57878,
+    "name": "Barki Saria",
+    "state_code": "JH"
+  },
+  {
+    "id": 57889,
+    "name": "Barwadih",
+    "state_code": "JH"
+  },
+  {
+    "id": 57992,
+    "name": "Bhojudih",
+    "state_code": "JH"
+  },
+  {
+    "id": 58076,
+    "name": "Bokaro",
+    "state_code": "JH"
+  },
+  {
+    "id": 58163,
+    "name": "Bundu",
+    "state_code": "JH"
+  },
+  {
+    "id": 131608,
+    "name": "Chaibasa",
+    "state_code": "JH"
+  },
+  {
+    "id": 58175,
+    "name": "Chakradharpur",
+    "state_code": "JH"
+  },
+  {
+    "id": 131591,
+    "name": "Chakulia",
+    "state_code": "JH"
+  },
+  {
+    "id": 131598,
+    "name": "Chandil",
+    "state_code": "JH"
+  },
+  {
+    "id": 131606,
+    "name": "Chas",
+    "state_code": "JH"
+  },
+  {
+    "id": 131511,
+    "name": "Chatra",
+    "state_code": "JH"
+  },
+  {
+    "id": 131570,
+    "name": "Chiria",
+    "state_code": "JH"
+  },
+  {
+    "id": 131648,
+    "name": "Daltonganj",
+    "state_code": "JH"
+  },
+  {
+    "id": 131684,
+    "name": "Deogarh",
+    "state_code": "JH"
+  },
+  {
+    "id": 131715,
+    "name": "Dhanbad",
+    "state_code": "JH"
+  },
+  {
+    "id": 131718,
+    "name": "Dhanwar",
+    "state_code": "JH"
+  },
+  {
+    "id": 131794,
+    "name": "Dugda",
+    "state_code": "JH"
+  },
+  {
+    "id": 131797,
+    "name": "Dumka",
+    "state_code": "JH"
+  },
+  {
+    "id": 131922,
+    "name": "Garhwa",
+    "state_code": "JH"
+  },
+  {
+    "id": 131952,
+    "name": "Ghatsila",
+    "state_code": "JH"
+  },
+  {
+    "id": 131959,
+    "name": "Giridih",
+    "state_code": "JH"
+  },
+  {
+    "id": 131962,
+    "name": "Gobindpur",
+    "state_code": "JH"
+  },
+  {
+    "id": 131963,
+    "name": "Godda",
+    "state_code": "JH"
+  },
+  {
+    "id": 131980,
+    "name": "Gomoh",
+    "state_code": "JH"
+  },
+  {
+    "id": 131986,
+    "name": "Gopinathpur",
+    "state_code": "JH"
+  },
+  {
+    "id": 132006,
+    "name": "Gua",
+    "state_code": "JH"
+  },
+  {
+    "id": 132020,
+    "name": "Gumia",
+    "state_code": "JH"
+  },
+  {
+    "id": 132021,
+    "name": "Gumla",
+    "state_code": "JH"
+  },
+  {
+    "id": 132092,
+    "name": "Hazaribag",
+    "state_code": "JH"
+  },
+  {
+    "id": 132091,
+    "name": "Hazaribagh",
+    "state_code": "JH"
+  },
+  {
+    "id": 132094,
+    "name": "Hesla",
+    "state_code": "JH"
+  },
+  {
+    "id": 132131,
+    "name": "Husainabad",
+    "state_code": "JH"
+  },
+  {
+    "id": 132183,
+    "name": "Jagannathpur",
+    "state_code": "JH"
+  },
+  {
+    "id": 132308,
+    "name": "Jamadoba",
+    "state_code": "JH"
+  },
+  {
+    "id": 132231,
+    "name": "Jamshedpur",
+    "state_code": "JH"
+  },
+  {
+    "id": 132232,
+    "name": "Jamtara",
+    "state_code": "JH"
+  },
+  {
+    "id": 132246,
+    "name": "Jasidih",
+    "state_code": "JH"
+  },
+  {
+    "id": 132268,
+    "name": "Jharia",
+    "state_code": "JH"
+  },
+  {
+    "id": 132299,
+    "name": "Jugsalai",
+    "state_code": "JH"
+  },
+  {
+    "id": 132300,
+    "name": "Jumri Tilaiya",
+    "state_code": "JH"
+  },
+  {
+    "id": 132680,
+    "name": "Kalikapur",
+    "state_code": "JH"
+  },
+  {
+    "id": 132699,
+    "name": "Kandra",
+    "state_code": "JH"
+  },
+  {
+    "id": 132703,
+    "name": "Kanke",
+    "state_code": "JH"
+  },
+  {
+    "id": 132727,
+    "name": "Katras",
+    "state_code": "JH"
+  },
+  {
+    "id": 132443,
+    "name": "Kenduadih",
+    "state_code": "JH"
+  },
+  {
+    "id": 132482,
+    "name": "Kharsawan",
+    "state_code": "JH"
+  },
+  {
+    "id": 132506,
+    "name": "Khunti",
+    "state_code": "JH"
+  },
+  {
+    "id": 132540,
+    "name": "Kodarma",
+    "state_code": "JH"
+  },
+  {
+    "id": 132630,
+    "name": "Kuju",
+    "state_code": "JH"
+  },
+  {
+    "id": 132758,
+    "name": "Latehar",
+    "state_code": "JH"
+  },
+  {
+    "id": 132768,
+    "name": "Lohardaga",
+    "state_code": "JH"
+  },
+  {
+    "id": 132816,
+    "name": "Madhupur",
+    "state_code": "JH"
+  },
+  {
+    "id": 132873,
+    "name": "Malkera",
+    "state_code": "JH"
+  },
+  {
+    "id": 132923,
+    "name": "Manoharpur",
+    "state_code": "JH"
+  },
+  {
+    "id": 133015,
+    "name": "Mugma",
+    "state_code": "JH"
+  },
+  {
+    "id": 133044,
+    "name": "Mushabani",
+    "state_code": "JH"
+  },
+  {
+    "id": 133209,
+    "name": "Neturhat",
+    "state_code": "JH"
+  },
+  {
+    "id": 133223,
+    "name": "Nirsa",
+    "state_code": "JH"
+  },
+  {
+    "id": 133246,
+    "name": "Noamundi",
+    "state_code": "JH"
+  },
+  {
+    "id": 133320,
+    "name": "Pakur",
+    "state_code": "JH"
+  },
+  {
+    "id": 133339,
+    "name": "Palamu",
+    "state_code": "JH"
+  },
+  {
+    "id": 133374,
+    "name": "Pashchim Singhbhum",
+    "state_code": "JH"
+  },
+  {
+    "id": 134446,
+    "name": "patamda",
+    "state_code": "JH"
+  },
+  {
+    "id": 133557,
+    "name": "Pathardih",
+    "state_code": "JH"
+  },
+  {
+    "id": 133510,
+    "name": "Purba Singhbhum",
+    "state_code": "JH"
+  },
+  {
+    "id": 133604,
+    "name": "Ramgarh",
+    "state_code": "JH"
+  },
+  {
+    "id": 133606,
+    "name": "Ranchi",
+    "state_code": "JH"
+  },
+  {
+    "id": 133727,
+    "name": "Ray",
+    "state_code": "JH"
+  },
+  {
+    "id": 133752,
+    "name": "Sahibganj",
+    "state_code": "JH"
+  },
+  {
+    "id": 133800,
+    "name": "Saraikela",
+    "state_code": "JH"
+  },
+  {
+    "id": 134079,
+    "name": "Sarubera",
+    "state_code": "JH"
+  },
+  {
+    "id": 133927,
+    "name": "Sijua",
+    "state_code": "JH"
+  },
+  {
+    "id": 133939,
+    "name": "Simdega",
+    "state_code": "JH"
+  },
+  {
+    "id": 133952,
+    "name": "Sini",
+    "state_code": "JH"
+  },
+  {
+    "id": 134209,
+    "name": "Topchanchi",
+    "state_code": "JH"
+  },
+  {
+    "id": 57598,
+    "name": "Afzalpur",
+    "state_code": "KA"
+  },
+  {
+    "id": 57613,
+    "name": "Ajjampur",
+    "state_code": "KA"
+  },
+  {
+    "id": 57632,
+    "name": "Aland",
+    "state_code": "KA"
+  },
+  {
+    "id": 57644,
+    "name": "Alnavar",
+    "state_code": "KA"
+  },
+  {
+    "id": 57656,
+    "name": "Alur",
+    "state_code": "KA"
+  },
+  {
+    "id": 57702,
+    "name": "Anekal",
+    "state_code": "KA"
+  },
+  {
+    "id": 57711,
+    "name": "Ankola",
+    "state_code": "KA"
+  },
+  {
+    "id": 57713,
+    "name": "Annigeri",
+    "state_code": "KA"
+  },
+  {
+    "id": 57735,
+    "name": "Arkalgud",
+    "state_code": "KA"
+  },
+  {
+    "id": 57740,
+    "name": "Arsikere",
+    "state_code": "KA"
+  },
+  {
+    "id": 57757,
+    "name": "Athni",
+    "state_code": "KA"
+  },
+  {
+    "id": 57768,
+    "name": "Aurad",
+    "state_code": "KA"
+  },
+  {
+    "id": 58105,
+    "name": "Badami",
+    "state_code": "KA"
+  },
+  {
+    "id": 57797,
+    "name": "Bagalkot",
+    "state_code": "KA"
+  },
+  {
+    "id": 58107,
+    "name": "Bagepalli",
+    "state_code": "KA"
+  },
+  {
+    "id": 57814,
+    "name": "Bail-Hongal",
+    "state_code": "KA"
+  },
+  {
+    "id": 57827,
+    "name": "Ballari",
+    "state_code": "KA"
+  },
+  {
+    "id": 58136,
+    "name": "Banavar",
+    "state_code": "KA"
+  },
+  {
+    "id": 57851,
+    "name": "Bangarapet",
+    "state_code": "KA"
+  },
+  {
+    "id": 57856,
+    "name": "Bannur",
+    "state_code": "KA"
+  },
+  {
+    "id": 57857,
+    "name": "Bantval",
+    "state_code": "KA"
+  },
+  {
+    "id": 57893,
+    "name": "Basavakalyan",
+    "state_code": "KA"
+  },
+  {
+    "id": 57894,
+    "name": "Basavana Bagevadi",
+    "state_code": "KA"
+  },
+  {
+    "id": 57922,
+    "name": "Belagavi",
+    "state_code": "KA"
+  },
+  {
+    "id": 57925,
+    "name": "Belluru",
+    "state_code": "KA"
+  },
+  {
+    "id": 57928,
+    "name": "Beltangadi",
+    "state_code": "KA"
+  },
+  {
+    "id": 57930,
+    "name": "Belur",
+    "state_code": "KA"
+  },
+  {
+    "id": 57933,
+    "name": "Bengaluru",
+    "state_code": "KA"
+  },
+  {
+    "id": 57847,
+    "name": "Bengaluru Rural",
+    "state_code": "KA"
+  },
+  {
+    "id": 57848,
+    "name": "Bengaluru Urban",
+    "state_code": "KA"
+  },
+  {
+    "id": 57956,
+    "name": "Bhadravati",
+    "state_code": "KA"
+  },
+  {
+    "id": 58010,
+    "name": "Bhalki",
+    "state_code": "KA"
+  },
+  {
+    "id": 57970,
+    "name": "Bhatkal",
+    "state_code": "KA"
+  },
+  {
+    "id": 58154,
+    "name": "Bidar",
+    "state_code": "KA"
+  },
+  {
+    "id": 58042,
+    "name": "Bilgi",
+    "state_code": "KA"
+  },
+  {
+    "id": 58061,
+    "name": "Birur",
+    "state_code": "KA"
+  },
+  {
+    "id": 58102,
+    "name": "Byadgi",
+    "state_code": "KA"
+  },
+  {
+    "id": 58101,
+    "name": "Byndoor",
+    "state_code": "KA"
+  },
+  {
+    "id": 58166,
+    "name": "Canacona",
+    "state_code": "KA"
+  },
+  {
+    "id": 58178,
+    "name": "Challakere",
+    "state_code": "KA"
+  },
+  {
+    "id": 58185,
+    "name": "Chamrajnagar",
+    "state_code": "KA"
+  },
+  {
+    "id": 58197,
+    "name": "Channagiri",
+    "state_code": "KA"
+  },
+  {
+    "id": 58198,
+    "name": "Channapatna",
+    "state_code": "KA"
+  },
+  {
+    "id": 58199,
+    "name": "Channarayapatna",
+    "state_code": "KA"
+  },
+  {
+    "id": 131547,
+    "name": "Chik Ballapur",
+    "state_code": "KA"
+  },
+  {
+    "id": 131551,
+    "name": "Chikkaballapur",
+    "state_code": "KA"
+  },
+  {
+    "id": 131552,
+    "name": "Chikkamagaluru",
+    "state_code": "KA"
+  },
+  {
+    "id": 131554,
+    "name": "Chiknayakanhalli",
+    "state_code": "KA"
+  },
+  {
+    "id": 131555,
+    "name": "Chikodi",
+    "state_code": "KA"
+  },
+  {
+    "id": 131560,
+    "name": "Chincholi",
+    "state_code": "KA"
+  },
+  {
+    "id": 131566,
+    "name": "Chintamani",
+    "state_code": "KA"
+  },
+  {
+    "id": 131613,
+    "name": "Chitapur",
+    "state_code": "KA"
+  },
+  {
+    "id": 131571,
+    "name": "Chitradurga",
+    "state_code": "KA"
+  },
+  {
+    "id": 131616,
+    "name": "Closepet",
+    "state_code": "KA"
+  },
+  {
+    "id": 131624,
+    "name": "Coondapoor",
+    "state_code": "KA"
+  },
+  {
+    "id": 131644,
+    "name": "Dakshina Kannada",
+    "state_code": "KA"
+  },
+  {
+    "id": 131652,
+    "name": "Dandeli",
+    "state_code": "KA"
+  },
+  {
+    "id": 131670,
+    "name": "Davanagere",
+    "state_code": "KA"
+  },
+  {
+    "id": 131701,
+    "name": "Devanhalli",
+    "state_code": "KA"
+  },
+  {
+    "id": 131729,
+    "name": "Dharwad",
+    "state_code": "KA"
+  },
+  {
+    "id": 131780,
+    "name": "Dod Ballapur",
+    "state_code": "KA"
+  },
+  {
+    "id": 131879,
+    "name": "French Rocks",
+    "state_code": "KA"
+  },
+  {
+    "id": 131884,
+    "name": "Gadag",
+    "state_code": "KA"
+  },
+  {
+    "id": 131885,
+    "name": "Gadag-Betageri",
+    "state_code": "KA"
+  },
+  {
+    "id": 131893,
+    "name": "Gajendragarh",
+    "state_code": "KA"
+  },
+  {
+    "id": 131911,
+    "name": "Gangawati",
+    "state_code": "KA"
+  },
+  {
+    "id": 131904,
+    "name": "Gangolli",
+    "state_code": "KA"
+  },
+  {
+    "id": 131970,
+    "name": "Gokak",
+    "state_code": "KA"
+  },
+  {
+    "id": 131971,
+    "name": "Gokarna",
+    "state_code": "KA"
+  },
+  {
+    "id": 131995,
+    "name": "Goribidnur",
+    "state_code": "KA"
+  },
+  {
+    "id": 131996,
+    "name": "Gorur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132007,
+    "name": "Gubbi",
+    "state_code": "KA"
+  },
+  {
+    "id": 132009,
+    "name": "Gudibanda",
+    "state_code": "KA"
+  },
+  {
+    "id": 132017,
+    "name": "Guledagudda",
+    "state_code": "KA"
+  },
+  {
+    "id": 132025,
+    "name": "Gundlupet",
+    "state_code": "KA"
+  },
+  {
+    "id": 132034,
+    "name": "Gurmatkal",
+    "state_code": "KA"
+  },
+  {
+    "id": 132053,
+    "name": "Hadagalli",
+    "state_code": "KA"
+  },
+  {
+    "id": 132059,
+    "name": "Haliyal",
+    "state_code": "KA"
+  },
+  {
+    "id": 132061,
+    "name": "Hampi",
+    "state_code": "KA"
+  },
+  {
+    "id": 132140,
+    "name": "Hangal",
+    "state_code": "KA"
+  },
+  {
+    "id": 132076,
+    "name": "Harihar",
+    "state_code": "KA"
+  },
+  {
+    "id": 132079,
+    "name": "Harpanahalli",
+    "state_code": "KA"
+  },
+  {
+    "id": 132086,
+    "name": "Hassan",
+    "state_code": "KA"
+  },
+  {
+    "id": 132089,
+    "name": "Haveri",
+    "state_code": "KA"
+  },
+  {
+    "id": 132093,
+    "name": "Heggadadevankote",
+    "state_code": "KA"
+  },
+  {
+    "id": 132103,
+    "name": "Hirekerur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132104,
+    "name": "Hiriyur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132111,
+    "name": "Holalkere",
+    "state_code": "KA"
+  },
+  {
+    "id": 132112,
+    "name": "Hole Narsipur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132113,
+    "name": "Homnabad",
+    "state_code": "KA"
+  },
+  {
+    "id": 132115,
+    "name": "Honavar",
+    "state_code": "KA"
+  },
+  {
+    "id": 132114,
+    "name": "Honnali",
+    "state_code": "KA"
+  },
+  {
+    "id": 132117,
+    "name": "Hosanagara",
+    "state_code": "KA"
+  },
+  {
+    "id": 132118,
+    "name": "Hosangadi",
+    "state_code": "KA"
+  },
+  {
+    "id": 132119,
+    "name": "Hosdurga",
+    "state_code": "KA"
+  },
+  {
+    "id": 132123,
+    "name": "Hoskote",
+    "state_code": "KA"
+  },
+  {
+    "id": 132124,
+    "name": "Hospet",
+    "state_code": "KA"
+  },
+  {
+    "id": 132127,
+    "name": "Hubballi",
+    "state_code": "KA"
+  },
+  {
+    "id": 132128,
+    "name": "Hukeri",
+    "state_code": "KA"
+  },
+  {
+    "id": 132129,
+    "name": "Hungund",
+    "state_code": "KA"
+  },
+  {
+    "id": 132130,
+    "name": "Hunsur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132160,
+    "name": "Ilkal",
+    "state_code": "KA"
+  },
+  {
+    "id": 132165,
+    "name": "Indi",
+    "state_code": "KA"
+  },
+  {
+    "id": 132182,
+    "name": "Jagalur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132227,
+    "name": "Jamkhandi",
+    "state_code": "KA"
+  },
+  {
+    "id": 132263,
+    "name": "Jevargi",
+    "state_code": "KA"
+  },
+  {
+    "id": 132330,
+    "name": "Kadur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132016,
+    "name": "Kalaburgi",
+    "state_code": "KA"
+  },
+  {
+    "id": 132351,
+    "name": "Kalghatgi",
+    "state_code": "KA"
+  },
+  {
+    "id": 132365,
+    "name": "Kampli",
+    "state_code": "KA"
+  },
+  {
+    "id": 132706,
+    "name": "Kankanhalli",
+    "state_code": "KA"
+  },
+  {
+    "id": 132719,
+    "name": "Karkala",
+    "state_code": "KA"
+  },
+  {
+    "id": 132411,
+    "name": "Karwar",
+    "state_code": "KA"
+  },
+  {
+    "id": 132431,
+    "name": "Kavalur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132445,
+    "name": "Kerur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132516,
+    "name": "Khanapur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132537,
+    "name": "Kodagu",
+    "state_code": "KA"
+  },
+  {
+    "id": 132541,
+    "name": "Kodigenahalli",
+    "state_code": "KA"
+  },
+  {
+    "id": 132542,
+    "name": "Kodlipet",
+    "state_code": "KA"
+  },
+  {
+    "id": 132553,
+    "name": "Kolar",
+    "state_code": "KA"
+  },
+  {
+    "id": 132559,
+    "name": "Kollegal",
+    "state_code": "KA"
+  },
+  {
+    "id": 132563,
+    "name": "Konanur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132569,
+    "name": "Konnur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132573,
+    "name": "Koppa",
+    "state_code": "KA"
+  },
+  {
+    "id": 132574,
+    "name": "Koppal",
+    "state_code": "KA"
+  },
+  {
+    "id": 132579,
+    "name": "Koratagere",
+    "state_code": "KA"
+  },
+  {
+    "id": 132610,
+    "name": "Kotturu",
+    "state_code": "KA"
+  },
+  {
+    "id": 132623,
+    "name": "Krishnarajpet",
+    "state_code": "KA"
+  },
+  {
+    "id": 132628,
+    "name": "Kudachi",
+    "state_code": "KA"
+  },
+  {
+    "id": 132736,
+    "name": "Kudligi",
+    "state_code": "KA"
+  },
+  {
+    "id": 132642,
+    "name": "Kumsi",
+    "state_code": "KA"
+  },
+  {
+    "id": 132643,
+    "name": "Kumta",
+    "state_code": "KA"
+  },
+  {
+    "id": 132646,
+    "name": "Kundgol",
+    "state_code": "KA"
+  },
+  {
+    "id": 132648,
+    "name": "Kunigal",
+    "state_code": "KA"
+  },
+  {
+    "id": 132658,
+    "name": "Kurgunta",
+    "state_code": "KA"
+  },
+  {
+    "id": 132668,
+    "name": "Kushalnagar",
+    "state_code": "KA"
+  },
+  {
+    "id": 132666,
+    "name": "Kushtagi",
+    "state_code": "KA"
+  },
+  {
+    "id": 132752,
+    "name": "Lakshmeshwar",
+    "state_code": "KA"
+  },
+  {
+    "id": 132765,
+    "name": "Lingsugur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132774,
+    "name": "Londa",
+    "state_code": "KA"
+  },
+  {
+    "id": 132809,
+    "name": "Maddagiri",
+    "state_code": "KA"
+  },
+  {
+    "id": 132810,
+    "name": "Maddur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132817,
+    "name": "Madikeri",
+    "state_code": "KA"
+  },
+  {
+    "id": 133060,
+    "name": "Magadi",
+    "state_code": "KA"
+  },
+  {
+    "id": 132847,
+    "name": "Mahalingpur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132868,
+    "name": "Malavalli",
+    "state_code": "KA"
+  },
+  {
+    "id": 132877,
+    "name": "Malpe",
+    "state_code": "KA"
+  },
+  {
+    "id": 133071,
+    "name": "Malur",
+    "state_code": "KA"
+  },
+  {
+    "id": 132898,
+    "name": "Mandya",
+    "state_code": "KA"
+  },
+  {
+    "id": 132905,
+    "name": "Mangaluru",
+    "state_code": "KA"
+  },
+  {
+    "id": 132912,
+    "name": "Manipal",
+    "state_code": "KA"
+  },
+  {
+    "id": 133083,
+    "name": "Manvi",
+    "state_code": "KA"
+  },
+  {
+    "id": 133093,
+    "name": "Mayakonda",
+    "state_code": "KA"
+  },
+  {
+    "id": 132964,
+    "name": "Melukote",
+    "state_code": "KA"
+  },
+  {
+    "id": 133098,
+    "name": "Mudbidri",
+    "state_code": "KA"
+  },
+  {
+    "id": 133008,
+    "name": "Muddebihal",
+    "state_code": "KA"
+  },
+  {
+    "id": 133009,
+    "name": "Mudgal",
+    "state_code": "KA"
+  },
+  {
+    "id": 133010,
+    "name": "Mudgere",
+    "state_code": "KA"
+  },
+  {
+    "id": 133011,
+    "name": "Mudhol",
+    "state_code": "KA"
+  },
+  {
+    "id": 133020,
+    "name": "Mulbagal",
+    "state_code": "KA"
+  },
+  {
+    "id": 133021,
+    "name": "Mulgund",
+    "state_code": "KA"
+  },
+  {
+    "id": 133101,
+    "name": "Mulki",
+    "state_code": "KA"
+  },
+  {
+    "id": 133026,
+    "name": "Mundargi",
+    "state_code": "KA"
+  },
+  {
+    "id": 133027,
+    "name": "Mundgod",
+    "state_code": "KA"
+  },
+  {
+    "id": 133033,
+    "name": "Munirabad",
+    "state_code": "KA"
+  },
+  {
+    "id": 133041,
+    "name": "Murudeshwara",
+    "state_code": "KA"
+  },
+  {
+    "id": 133053,
+    "name": "Mysuru",
+    "state_code": "KA"
+  },
+  {
+    "id": 133254,
+    "name": "Nagamangala",
+    "state_code": "KA"
+  },
+  {
+    "id": 133151,
+    "name": "Nanjangud",
+    "state_code": "KA"
+  },
+  {
+    "id": 133159,
+    "name": "Narasimharajapura",
+    "state_code": "KA"
+  },
+  {
+    "id": 133164,
+    "name": "Naregal",
+    "state_code": "KA"
+  },
+  {
+    "id": 133167,
+    "name": "Nargund",
+    "state_code": "KA"
+  },
+  {
+    "id": 133184,
+    "name": "Navalgund",
+    "state_code": "KA"
+  },
+  {
+    "id": 133204,
+    "name": "Nelamangala",
+    "state_code": "KA"
+  },
+  {
+    "id": 133249,
+    "name": "Nyamti",
+    "state_code": "KA"
+  },
+  {
+    "id": 133541,
+    "name": "Pangala",
+    "state_code": "KA"
+  },
+  {
+    "id": 133560,
+    "name": "Pavugada",
+    "state_code": "KA"
+  },
+  {
+    "id": 133458,
+    "name": "Piriyapatna",
+    "state_code": "KA"
+  },
+  {
+    "id": 133474,
+    "name": "Ponnampet",
+    "state_code": "KA"
+  },
+  {
+    "id": 133518,
+    "name": "Puttur",
+    "state_code": "KA"
+  },
+  {
+    "id": 133577,
+    "name": "Rabkavi",
+    "state_code": "KA"
+  },
+  {
+    "id": 133586,
+    "name": "Raichur",
+    "state_code": "KA"
+  },
+  {
+    "id": 133598,
+    "name": "Ramanagara",
+    "state_code": "KA"
+  },
+  {
+    "id": 133719,
+    "name": "Ranibennur",
+    "state_code": "KA"
+  },
+  {
+    "id": 133731,
+    "name": "Raybag",
+    "state_code": "KA"
+  },
+  {
+    "id": 133642,
+    "name": "Robertsonpet",
+    "state_code": "KA"
+  },
+  {
+    "id": 133649,
+    "name": "Ron",
+    "state_code": "KA"
+  },
+  {
+    "id": 133743,
+    "name": "Sadalgi",
+    "state_code": "KA"
+  },
+  {
+    "id": 134060,
+    "name": "Sagar",
+    "state_code": "KA"
+  },
+  {
+    "id": 133760,
+    "name": "Sakleshpur",
+    "state_code": "KA"
+  },
+  {
+    "id": 133779,
+    "name": "Sandur",
+    "state_code": "KA"
+  },
+  {
+    "id": 133788,
+    "name": "Sanivarsante",
+    "state_code": "KA"
+  },
+  {
+    "id": 133789,
+    "name": "Sankeshwar",
+    "state_code": "KA"
+  },
+  {
+    "id": 133806,
+    "name": "Sargur",
+    "state_code": "KA"
+  },
+  {
+    "id": 133827,
+    "name": "Saundatti",
+    "state_code": "KA"
+  },
+  {
+    "id": 133830,
+    "name": "Savanur",
+    "state_code": "KA"
+  },
+  {
+    "id": 133846,
+    "name": "Seram",
+    "state_code": "KA"
+  },
+  {
+    "id": 133907,
+    "name": "Shahabad",
+    "state_code": "KA"
+  },
+  {
+    "id": 133898,
+    "name": "Shahpur",
+    "state_code": "KA"
+  },
+  {
+    "id": 133866,
+    "name": "Shiggaon",
+    "state_code": "KA"
+  },
+  {
+    "id": 133868,
+    "name": "Shikarpur",
+    "state_code": "KA"
+  },
+  {
+    "id": 133872,
+    "name": "Shimoga",
+    "state_code": "KA"
+  },
+  {
+    "id": 133876,
+    "name": "Shirhatti",
+    "state_code": "KA"
+  },
+  {
+    "id": 133884,
+    "name": "Shorapur",
+    "state_code": "KA"
+  },
+  {
+    "id": 133887,
+    "name": "Shrirangapattana",
+    "state_code": "KA"
+  },
+  {
+    "id": 133920,
+    "name": "Siddapur",
+    "state_code": "KA"
+  },
+  {
+    "id": 133924,
+    "name": "Sidlaghatta",
+    "state_code": "KA"
+  },
+  {
+    "id": 133941,
+    "name": "Sindgi",
+    "state_code": "KA"
+  },
+  {
+    "id": 133942,
+    "name": "Sindhnur",
+    "state_code": "KA"
+  },
+  {
+    "id": 134087,
+    "name": "Sira",
+    "state_code": "KA"
+  },
+  {
+    "id": 133962,
+    "name": "Sirsi",
+    "state_code": "KA"
+  },
+  {
+    "id": 133967,
+    "name": "Siruguppa",
+    "state_code": "KA"
+  },
+  {
+    "id": 133989,
+    "name": "Someshwar",
+    "state_code": "KA"
+  },
+  {
+    "id": 133991,
+    "name": "Somvarpet",
+    "state_code": "KA"
+  },
+  {
+    "id": 134001,
+    "name": "Sorab",
+    "state_code": "KA"
+  },
+  {
+    "id": 134024,
+    "name": "Sravana Belgola",
+    "state_code": "KA"
+  },
+  {
+    "id": 134021,
+    "name": "Sringeri",
+    "state_code": "KA"
+  },
+  {
+    "id": 134029,
+    "name": "Srinivaspur",
+    "state_code": "KA"
+  },
+  {
+    "id": 134042,
+    "name": "Sulya",
+    "state_code": "KA"
+  },
+  {
+    "id": 134047,
+    "name": "Suntikoppa",
+    "state_code": "KA"
+  },
+  {
+    "id": 134234,
+    "name": "Talikota",
+    "state_code": "KA"
+  },
+  {
+    "id": 134116,
+    "name": "Tarikere",
+    "state_code": "KA"
+  },
+  {
+    "id": 134125,
+    "name": "Tekkalakote",
+    "state_code": "KA"
+  },
+  {
+    "id": 134133,
+    "name": "Terdal",
+    "state_code": "KA"
+  },
+  {
+    "id": 134176,
+    "name": "Tiptur",
+    "state_code": "KA"
+  },
+  {
+    "id": 134247,
+    "name": "Tirthahalli",
+    "state_code": "KA"
+  },
+  {
+    "id": 134182,
+    "name": "Tirumakudal Narsipur",
+    "state_code": "KA"
+  },
+  {
+    "id": 134219,
+    "name": "Tumakuru",
+    "state_code": "KA"
+  },
+  {
+    "id": 134225,
+    "name": "Turuvekere",
+    "state_code": "KA"
+  },
+  {
+    "id": 134260,
+    "name": "Udupi",
+    "state_code": "KA"
+  },
+  {
+    "id": 134268,
+    "name": "Ullal",
+    "state_code": "KA"
+  },
+  {
+    "id": 134300,
+    "name": "Uttar Kannada",
+    "state_code": "KA"
+  },
+  {
+    "id": 134307,
+    "name": "Vadigenhalli",
+    "state_code": "KA"
+  },
+  {
+    "id": 58031,
+    "name": "Vijayapura",
+    "state_code": "KA"
+  },
+  {
+    "id": 134386,
+    "name": "Virarajendrapet",
+    "state_code": "KA"
+  },
+  {
+    "id": 134414,
+    "name": "Wadi",
+    "state_code": "KA"
+  },
+  {
+    "id": 134420,
+    "name": "Yadgir",
+    "state_code": "KA"
+  },
+  {
+    "id": 134429,
+    "name": "Yelahanka",
+    "state_code": "KA"
+  },
+  {
+    "id": 134430,
+    "name": "Yelandur",
+    "state_code": "KA"
+  },
+  {
+    "id": 134431,
+    "name": "Yelbarga",
+    "state_code": "KA"
+  },
+  {
+    "id": 134433,
+    "name": "Yellapur",
+    "state_code": "KA"
+  },
+  {
+    "id": 57596,
+    "name": "Adoor",
+    "state_code": "KL"
+  },
+  {
+    "id": 57637,
+    "name": "Alappuzha",
+    "state_code": "KL"
+  },
+  {
+    "id": 57647,
+    "name": "Aluva",
+    "state_code": "KL"
+  },
+  {
+    "id": 57650,
+    "name": "Alwaye",
+    "state_code": "KL"
+  },
+  {
+    "id": 57703,
+    "name": "Angamali",
+    "state_code": "KL"
+  },
+  {
+    "id": 57738,
+    "name": "Aroor",
+    "state_code": "KL"
+  },
+  {
+    "id": 57742,
+    "name": "Arukutti",
+    "state_code": "KL"
+  },
+  {
+    "id": 57762,
+    "name": "Attingal",
+    "state_code": "KL"
+  },
+  {
+    "id": 57772,
+    "name": "Avanoor",
+    "state_code": "KL"
+  },
+  {
+    "id": 57778,
+    "name": "Azhikkal",
+    "state_code": "KL"
+  },
+  {
+    "id": 57945,
+    "name": "Beypore",
+    "state_code": "KL"
+  },
+  {
+    "id": 58195,
+    "name": "Changanacheri",
+    "state_code": "KL"
+  },
+  {
+    "id": 131609,
+    "name": "Chelakara",
+    "state_code": "KL"
+  },
+  {
+    "id": 131516,
+    "name": "Chengannur",
+    "state_code": "KL"
+  },
+  {
+    "id": 131519,
+    "name": "Cherpulassery",
+    "state_code": "KL"
+  },
+  {
+    "id": 131521,
+    "name": "Cherthala",
+    "state_code": "KL"
+  },
+  {
+    "id": 131524,
+    "name": "Chetwayi",
+    "state_code": "KL"
+  },
+  {
+    "id": 131576,
+    "name": "Chittur",
+    "state_code": "KL"
+  },
+  {
+    "id": 131617,
+    "name": "Cochin",
+    "state_code": "KL"
+  },
+  {
+    "id": 131724,
+    "name": "Dharmadom",
+    "state_code": "KL"
+  },
+  {
+    "id": 131829,
+    "name": "Edakkulam",
+    "state_code": "KL"
+  },
+  {
+    "id": 131835,
+    "name": "Elur",
+    "state_code": "KL"
+  },
+  {
+    "id": 131844,
+    "name": "Erattupetta",
+    "state_code": "KL"
+  },
+  {
+    "id": 131840,
+    "name": "Ernakulam",
+    "state_code": "KL"
+  },
+  {
+    "id": 131874,
+    "name": "Ferokh",
+    "state_code": "KL"
+  },
+  {
+    "id": 132038,
+    "name": "Guruvayur",
+    "state_code": "KL"
+  },
+  {
+    "id": 132154,
+    "name": "Idukki",
+    "state_code": "KL"
+  },
+  {
+    "id": 132170,
+    "name": "Iringal",
+    "state_code": "KL"
+  },
+  {
+    "id": 132171,
+    "name": "Irinjalakuda",
+    "state_code": "KL"
+  },
+  {
+    "id": 132323,
+    "name": "Kadakkavoor",
+    "state_code": "KL"
+  },
+  {
+    "id": 132344,
+    "name": "Kalamassery",
+    "state_code": "KL"
+  },
+  {
+    "id": 132350,
+    "name": "Kalavoor",
+    "state_code": "KL"
+  },
+  {
+    "id": 132356,
+    "name": "Kalpetta",
+    "state_code": "KL"
+  },
+  {
+    "id": 132707,
+    "name": "Kanhangad",
+    "state_code": "KL"
+  },
+  {
+    "id": 132379,
+    "name": "Kannavam",
+    "state_code": "KL"
+  },
+  {
+    "id": 132383,
+    "name": "Kannur",
+    "state_code": "KL"
+  },
+  {
+    "id": 132720,
+    "name": "Kasaragod",
+    "state_code": "KL"
+  },
+  {
+    "id": 132428,
+    "name": "Kattanam",
+    "state_code": "KL"
+  },
+  {
+    "id": 132731,
+    "name": "Kayankulam",
+    "state_code": "KL"
+  },
+  {
+    "id": 132536,
+    "name": "Kizhake Chalakudi",
+    "state_code": "KL"
+  },
+  {
+    "id": 132545,
+    "name": "Kodungallur",
+    "state_code": "KL"
+  },
+  {
+    "id": 132558,
+    "name": "Kollam",
+    "state_code": "KL"
+  },
+  {
+    "id": 132595,
+    "name": "Kotamangalam",
+    "state_code": "KL"
+  },
+  {
+    "id": 132609,
+    "name": "Kottayam",
+    "state_code": "KL"
+  },
+  {
+    "id": 132614,
+    "name": "Kovalam",
+    "state_code": "KL"
+  },
+  {
+    "id": 132619,
+    "name": "Kozhikode",
+    "state_code": "KL"
+  },
+  {
+    "id": 132639,
+    "name": "Kumbalam",
+    "state_code": "KL"
+  },
+  {
+    "id": 132649,
+    "name": "Kunnamangalam",
+    "state_code": "KL"
+  },
+  {
+    "id": 132650,
+    "name": "Kunnamkulam",
+    "state_code": "KL"
+  },
+  {
+    "id": 132652,
+    "name": "Kunnumma",
+    "state_code": "KL"
+  },
+  {
+    "id": 132669,
+    "name": "Kutiatodu",
+    "state_code": "KL"
+  },
+  {
+    "id": 132671,
+    "name": "Kuttampuzha",
+    "state_code": "KL"
+  },
+  {
+    "id": 132794,
+    "name": "Lalam",
+    "state_code": "KL"
+  },
+  {
+    "id": 132852,
+    "name": "Mahe",
+    "state_code": "KL"
+  },
+  {
+    "id": 132866,
+    "name": "Malappuram",
+    "state_code": "KL"
+  },
+  {
+    "id": 132913,
+    "name": "Manjeri",
+    "state_code": "KL"
+  },
+  {
+    "id": 132915,
+    "name": "Manjeshwaram",
+    "state_code": "KL"
+  },
+  {
+    "id": 132920,
+    "name": "Mannarakkat",
+    "state_code": "KL"
+  },
+  {
+    "id": 132933,
+    "name": "Marayur",
+    "state_code": "KL"
+  },
+  {
+    "id": 132942,
+    "name": "Mattanur",
+    "state_code": "KL"
+  },
+  {
+    "id": 133092,
+    "name": "Mavelikara",
+    "state_code": "KL"
+  },
+  {
+    "id": 132950,
+    "name": "Mavoor",
+    "state_code": "KL"
+  },
+  {
+    "id": 133023,
+    "name": "Muluppilagadu",
+    "state_code": "KL"
+  },
+  {
+    "id": 133034,
+    "name": "Munnar",
+    "state_code": "KL"
+  },
+  {
+    "id": 133103,
+    "name": "Muvattupula",
+    "state_code": "KL"
+  },
+  {
+    "id": 133050,
+    "name": "Muvattupuzha",
+    "state_code": "KL"
+  },
+  {
+    "id": 133253,
+    "name": "Nadapuram",
+    "state_code": "KL"
+  },
+  {
+    "id": 133107,
+    "name": "Naduvannur",
+    "state_code": "KL"
+  },
+  {
+    "id": 133198,
+    "name": "Nedumangad",
+    "state_code": "KL"
+  },
+  {
+    "id": 133211,
+    "name": "Neyyattinkara",
+    "state_code": "KL"
+  },
+  {
+    "id": 133287,
+    "name": "Nileshwar",
+    "state_code": "KL"
+  },
+  {
+    "id": 133306,
+    "name": "Ottappalam",
+    "state_code": "KL"
+  },
+  {
+    "id": 133321,
+    "name": "Palackattumala",
+    "state_code": "KL"
+  },
+  {
+    "id": 133322,
+    "name": "Palakkad district",
+    "state_code": "KL"
+  },
+  {
+    "id": 133528,
+    "name": "Palghat",
+    "state_code": "KL"
+  },
+  {
+    "id": 133343,
+    "name": "Panamaram",
+    "state_code": "KL"
+  },
+  {
+    "id": 133546,
+    "name": "Pappinissheri",
+    "state_code": "KL"
+  },
+  {
+    "id": 133357,
+    "name": "Paravur Tekkumbhagam",
+    "state_code": "KL"
+  },
+  {
+    "id": 133359,
+    "name": "Pariyapuram",
+    "state_code": "KL"
+  },
+  {
+    "id": 133380,
+    "name": "Pathanamthitta",
+    "state_code": "KL"
+  },
+  {
+    "id": 133389,
+    "name": "Pattanamtitta",
+    "state_code": "KL"
+  },
+  {
+    "id": 133399,
+    "name": "Payyanur",
+    "state_code": "KL"
+  },
+  {
+    "id": 153628,
+    "name": "Perinthalmanna",
+    "state_code": "KL"
+  },
+  {
+    "id": 133423,
+    "name": "Perumbavoor",
+    "state_code": "KL"
+  },
+  {
+    "id": 133424,
+    "name": "Perumpavur",
+    "state_code": "KL"
+  },
+  {
+    "id": 133427,
+    "name": "Perya",
+    "state_code": "KL"
+  },
+  {
+    "id": 133457,
+    "name": "Piravam",
+    "state_code": "KL"
+  },
+  {
+    "id": 133472,
+    "name": "Ponmana",
+    "state_code": "KL"
+  },
+  {
+    "id": 133477,
+    "name": "Ponnani",
+    "state_code": "KL"
+  },
+  {
+    "id": 133502,
+    "name": "Punalur",
+    "state_code": "KL"
+  },
+  {
+    "id": 133692,
+    "name": "Ramamangalam",
+    "state_code": "KL"
+  },
+  {
+    "id": 133865,
+    "name": "Shertallai",
+    "state_code": "KL"
+  },
+  {
+    "id": 133915,
+    "name": "Shoranur",
+    "state_code": "KL"
+  },
+  {
+    "id": 134103,
+    "name": "Taliparamba",
+    "state_code": "KL"
+  },
+  {
+    "id": 134129,
+    "name": "Thalassery",
+    "state_code": "KL"
+  },
+  {
+    "id": 134142,
+    "name": "Thanniyam",
+    "state_code": "KL"
+  },
+  {
+    "id": 134154,
+    "name": "Thiruvananthapuram",
+    "state_code": "KL"
+  },
+  {
+    "id": 134161,
+    "name": "Thrissur",
+    "state_code": "KL"
+  },
+  {
+    "id": 134192,
+    "name": "Tirur",
+    "state_code": "KL"
+  },
+  {
+    "id": 134194,
+    "name": "Tiruvalla",
+    "state_code": "KL"
+  },
+  {
+    "id": 134313,
+    "name": "Vaikam",
+    "state_code": "KL"
+  },
+  {
+    "id": 134330,
+    "name": "Varkala",
+    "state_code": "KL"
+  },
+  {
+    "id": 57786,
+    "name": "Vatakara",
+    "state_code": "KL"
+  },
+  {
+    "id": 134336,
+    "name": "Vayalar",
+    "state_code": "KL"
+  },
+  {
+    "id": 134353,
+    "name": "Vettur",
+    "state_code": "KL"
+  },
+  {
+    "id": 134400,
+    "name": "Wayanad",
+    "state_code": "KL"
+  },
+  {
+    "id": 132399,
+    "name": "Kargil",
+    "state_code": "LA"
+  },
+  {
+    "id": 132762,
+    "name": "Leh",
+    "state_code": "LA"
+  },
+  {
+    "id": 132432,
+    "name": "Kavaratti",
+    "state_code": "LD"
+  },
+  {
+    "id": 132750,
+    "name": "Lakshadweep",
+    "state_code": "LD"
+  },
+  {
+    "id": 57599,
+    "name": "Agar",
+    "state_code": "MP"
+  },
+  {
+    "id": 57611,
+    "name": "Ajaigarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 57626,
+    "name": "Akodia",
+    "state_code": "MP"
+  },
+  {
+    "id": 57631,
+    "name": "Alampur",
+    "state_code": "MP"
+  },
+  {
+    "id": 57639,
+    "name": "Alirajpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 57646,
+    "name": "Alot",
+    "state_code": "MP"
+  },
+  {
+    "id": 57691,
+    "name": "Amanganj",
+    "state_code": "MP"
+  },
+  {
+    "id": 57659,
+    "name": "Amarkantak",
+    "state_code": "MP"
+  },
+  {
+    "id": 57663,
+    "name": "Amarpatan",
+    "state_code": "MP"
+  },
+  {
+    "id": 57664,
+    "name": "Amarwara",
+    "state_code": "MP"
+  },
+  {
+    "id": 57673,
+    "name": "Ambah",
+    "state_code": "MP"
+  },
+  {
+    "id": 57680,
+    "name": "Amla",
+    "state_code": "MP"
+  },
+  {
+    "id": 57706,
+    "name": "Anjad",
+    "state_code": "MP"
+  },
+  {
+    "id": 57719,
+    "name": "Antri",
+    "state_code": "MP"
+  },
+  {
+    "id": 57721,
+    "name": "Anuppur",
+    "state_code": "MP"
+  },
+  {
+    "id": 134462,
+    "name": "Aron",
+    "state_code": "MP"
+  },
+  {
+    "id": 57750,
+    "name": "Ashoknagar",
+    "state_code": "MP"
+  },
+  {
+    "id": 57752,
+    "name": "Ashta",
+    "state_code": "MP"
+  },
+  {
+    "id": 58103,
+    "name": "Babai",
+    "state_code": "MP"
+  },
+  {
+    "id": 57788,
+    "name": "Badarwas",
+    "state_code": "MP"
+  },
+  {
+    "id": 57793,
+    "name": "Badnawar",
+    "state_code": "MP"
+  },
+  {
+    "id": 58106,
+    "name": "Bagh",
+    "state_code": "MP"
+  },
+  {
+    "id": 58111,
+    "name": "Bagli",
+    "state_code": "MP"
+  },
+  {
+    "id": 57811,
+    "name": "Baihar",
+    "state_code": "MP"
+  },
+  {
+    "id": 57813,
+    "name": "Baikunthpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 57821,
+    "name": "Bakshwaha",
+    "state_code": "MP"
+  },
+  {
+    "id": 58119,
+    "name": "Balaghat",
+    "state_code": "MP"
+  },
+  {
+    "id": 57824,
+    "name": "Baldeogarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 57838,
+    "name": "Bamna",
+    "state_code": "MP"
+  },
+  {
+    "id": 58122,
+    "name": "Bamor Kalan",
+    "state_code": "MP"
+  },
+  {
+    "id": 57839,
+    "name": "Bamora",
+    "state_code": "MP"
+  },
+  {
+    "id": 57842,
+    "name": "Banda",
+    "state_code": "MP"
+  },
+  {
+    "id": 57868,
+    "name": "Barela",
+    "state_code": "MP"
+  },
+  {
+    "id": 57870,
+    "name": "Barghat",
+    "state_code": "MP"
+  },
+  {
+    "id": 57871,
+    "name": "Bargi",
+    "state_code": "MP"
+  },
+  {
+    "id": 57872,
+    "name": "Barhi",
+    "state_code": "MP"
+  },
+  {
+    "id": 57888,
+    "name": "Barwani",
+    "state_code": "MP"
+  },
+  {
+    "id": 58148,
+    "name": "Basoda",
+    "state_code": "MP"
+  },
+  {
+    "id": 57913,
+    "name": "Begamganj",
+    "state_code": "MP"
+  },
+  {
+    "id": 57935,
+    "name": "Beohari",
+    "state_code": "MP"
+  },
+  {
+    "id": 57936,
+    "name": "Berasia",
+    "state_code": "MP"
+  },
+  {
+    "id": 57940,
+    "name": "Betma",
+    "state_code": "MP"
+  },
+  {
+    "id": 57942,
+    "name": "Betul",
+    "state_code": "MP"
+  },
+  {
+    "id": 57943,
+    "name": "Betul Bazar",
+    "state_code": "MP"
+  },
+  {
+    "id": 58006,
+    "name": "Bhabhra",
+    "state_code": "MP"
+  },
+  {
+    "id": 57959,
+    "name": "Bhainsdehi",
+    "state_code": "MP"
+  },
+  {
+    "id": 58011,
+    "name": "Bhander",
+    "state_code": "MP"
+  },
+  {
+    "id": 58012,
+    "name": "Bhanpura",
+    "state_code": "MP"
+  },
+  {
+    "id": 57975,
+    "name": "Bhawaniganj",
+    "state_code": "MP"
+  },
+  {
+    "id": 57980,
+    "name": "Bhikangaon",
+    "state_code": "MP"
+  },
+  {
+    "id": 57982,
+    "name": "Bhind",
+    "state_code": "MP"
+  },
+  {
+    "id": 57985,
+    "name": "Bhitarwar",
+    "state_code": "MP"
+  },
+  {
+    "id": 57995,
+    "name": "Bhopal",
+    "state_code": "MP"
+  },
+  {
+    "id": 58025,
+    "name": "Biaora",
+    "state_code": "MP"
+  },
+  {
+    "id": 58038,
+    "name": "Bijawar",
+    "state_code": "MP"
+  },
+  {
+    "id": 58036,
+    "name": "Bijrauni",
+    "state_code": "MP"
+  },
+  {
+    "id": 58073,
+    "name": "Bodri",
+    "state_code": "MP"
+  },
+  {
+    "id": 58096,
+    "name": "Burhanpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 58097,
+    "name": "Burhar",
+    "state_code": "MP"
+  },
+  {
+    "id": 58188,
+    "name": "Chanderi",
+    "state_code": "MP"
+  },
+  {
+    "id": 58189,
+    "name": "Chandia",
+    "state_code": "MP"
+  },
+  {
+    "id": 58191,
+    "name": "Chandla",
+    "state_code": "MP"
+  },
+  {
+    "id": 131532,
+    "name": "Chhatarpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 131534,
+    "name": "Chhindwara",
+    "state_code": "MP"
+  },
+  {
+    "id": 131543,
+    "name": "Chichli",
+    "state_code": "MP"
+  },
+  {
+    "id": 131581,
+    "name": "Chorhat",
+    "state_code": "MP"
+  },
+  {
+    "id": 131636,
+    "name": "Daboh",
+    "state_code": "MP"
+  },
+  {
+    "id": 131637,
+    "name": "Dabra",
+    "state_code": "MP"
+  },
+  {
+    "id": 131651,
+    "name": "Damoh",
+    "state_code": "MP"
+  },
+  {
+    "id": 131662,
+    "name": "Datia",
+    "state_code": "MP"
+  },
+  {
+    "id": 131691,
+    "name": "Deori Khas",
+    "state_code": "MP"
+  },
+  {
+    "id": 131693,
+    "name": "Depalpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 131707,
+    "name": "Dewas",
+    "state_code": "MP"
+  },
+  {
+    "id": 131749,
+    "name": "Dhamnod",
+    "state_code": "MP"
+  },
+  {
+    "id": 131751,
+    "name": "Dhana",
+    "state_code": "MP"
+  },
+  {
+    "id": 131753,
+    "name": "Dhar",
+    "state_code": "MP"
+  },
+  {
+    "id": 131720,
+    "name": "Dharampuri",
+    "state_code": "MP"
+  },
+  {
+    "id": 131775,
+    "name": "Dindori",
+    "state_code": "MP"
+  },
+  {
+    "id": 131848,
+    "name": "Etawa",
+    "state_code": "MP"
+  },
+  {
+    "id": 132043,
+    "name": "Gadarwara",
+    "state_code": "MP"
+  },
+  {
+    "id": 131917,
+    "name": "Garha Brahman",
+    "state_code": "MP"
+  },
+  {
+    "id": 131924,
+    "name": "Garhakota",
+    "state_code": "MP"
+  },
+  {
+    "id": 131930,
+    "name": "Gautampura",
+    "state_code": "MP"
+  },
+  {
+    "id": 131936,
+    "name": "Ghansor",
+    "state_code": "MP"
+  },
+  {
+    "id": 131965,
+    "name": "Gogapur",
+    "state_code": "MP"
+  },
+  {
+    "id": 131966,
+    "name": "Gohadi",
+    "state_code": "MP"
+  },
+  {
+    "id": 132002,
+    "name": "Govindgarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 132024,
+    "name": "Guna",
+    "state_code": "MP"
+  },
+  {
+    "id": 132033,
+    "name": "Gurh",
+    "state_code": "MP"
+  },
+  {
+    "id": 132040,
+    "name": "Gwalior",
+    "state_code": "MP"
+  },
+  {
+    "id": 132070,
+    "name": "Harda",
+    "state_code": "MP"
+  },
+  {
+    "id": 132071,
+    "name": "Harda Khas",
+    "state_code": "MP"
+  },
+  {
+    "id": 132080,
+    "name": "Harpalpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 132081,
+    "name": "Harrai",
+    "state_code": "MP"
+  },
+  {
+    "id": 132082,
+    "name": "Harsud",
+    "state_code": "MP"
+  },
+  {
+    "id": 132145,
+    "name": "Hatod",
+    "state_code": "MP"
+  },
+  {
+    "id": 132088,
+    "name": "Hatta",
+    "state_code": "MP"
+  },
+  {
+    "id": 132098,
+    "name": "Hindoria",
+    "state_code": "MP"
+  },
+  {
+    "id": 132120,
+    "name": "Hoshangabad",
+    "state_code": "MP"
+  },
+  {
+    "id": 132180,
+    "name": "Iawar",
+    "state_code": "MP"
+  },
+  {
+    "id": 132152,
+    "name": "Ichhawar",
+    "state_code": "MP"
+  },
+  {
+    "id": 132158,
+    "name": "Iklehra",
+    "state_code": "MP"
+  },
+  {
+    "id": 132166,
+    "name": "Indore",
+    "state_code": "MP"
+  },
+  {
+    "id": 132175,
+    "name": "Isagarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 132179,
+    "name": "Itarsi",
+    "state_code": "MP"
+  },
+  {
+    "id": 132181,
+    "name": "Jabalpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 132204,
+    "name": "Jaisinghnagar",
+    "state_code": "MP"
+  },
+  {
+    "id": 132206,
+    "name": "Jaithari",
+    "state_code": "MP"
+  },
+  {
+    "id": 132309,
+    "name": "Jamai",
+    "state_code": "MP"
+  },
+  {
+    "id": 132241,
+    "name": "Jaora",
+    "state_code": "MP"
+  },
+  {
+    "id": 132251,
+    "name": "Jatara",
+    "state_code": "MP"
+  },
+  {
+    "id": 132314,
+    "name": "Jawad",
+    "state_code": "MP"
+  },
+  {
+    "id": 132275,
+    "name": "Jhabua",
+    "state_code": "MP"
+  },
+  {
+    "id": 132316,
+    "name": "Jiran",
+    "state_code": "MP"
+  },
+  {
+    "id": 132283,
+    "name": "Jobat",
+    "state_code": "MP"
+  },
+  {
+    "id": 132333,
+    "name": "Kailaras",
+    "state_code": "MP"
+  },
+  {
+    "id": 132336,
+    "name": "Kaimori",
+    "state_code": "MP"
+  },
+  {
+    "id": 132382,
+    "name": "Kannod",
+    "state_code": "MP"
+  },
+  {
+    "id": 132397,
+    "name": "Kareli",
+    "state_code": "MP"
+  },
+  {
+    "id": 132398,
+    "name": "Karera",
+    "state_code": "MP"
+  },
+  {
+    "id": 132407,
+    "name": "Karrapur",
+    "state_code": "MP"
+  },
+  {
+    "id": 132419,
+    "name": "Kasrawad",
+    "state_code": "MP"
+  },
+  {
+    "id": 132420,
+    "name": "Katangi",
+    "state_code": "MP"
+  },
+  {
+    "id": 132424,
+    "name": "Katni",
+    "state_code": "MP"
+  },
+  {
+    "id": 132511,
+    "name": "Khachrod",
+    "state_code": "MP"
+  },
+  {
+    "id": 132453,
+    "name": "Khailar",
+    "state_code": "MP"
+  },
+  {
+    "id": 132457,
+    "name": "Khajuraho Group of Monuments",
+    "state_code": "MP"
+  },
+  {
+    "id": 132460,
+    "name": "Khamaria",
+    "state_code": "MP"
+  },
+  {
+    "id": 132467,
+    "name": "Khandwa",
+    "state_code": "MP"
+  },
+  {
+    "id": 132476,
+    "name": "Khargapur",
+    "state_code": "MP"
+  },
+  {
+    "id": 132474,
+    "name": "Khargone",
+    "state_code": "MP"
+  },
+  {
+    "id": 132519,
+    "name": "Khategaon",
+    "state_code": "MP"
+  },
+  {
+    "id": 132497,
+    "name": "Khilchipur",
+    "state_code": "MP"
+  },
+  {
+    "id": 132498,
+    "name": "Khirkiyan",
+    "state_code": "MP"
+  },
+  {
+    "id": 132504,
+    "name": "Khujner",
+    "state_code": "MP"
+  },
+  {
+    "id": 132507,
+    "name": "Khurai",
+    "state_code": "MP"
+  },
+  {
+    "id": 132561,
+    "name": "Kolaras",
+    "state_code": "MP"
+  },
+  {
+    "id": 132585,
+    "name": "Korwai",
+    "state_code": "MP"
+  },
+  {
+    "id": 132613,
+    "name": "Kotar",
+    "state_code": "MP"
+  },
+  {
+    "id": 132598,
+    "name": "Kothi",
+    "state_code": "MP"
+  },
+  {
+    "id": 132603,
+    "name": "Kotma",
+    "state_code": "MP"
+  },
+  {
+    "id": 132611,
+    "name": "Kotwa",
+    "state_code": "MP"
+  },
+  {
+    "id": 132631,
+    "name": "Kukshi",
+    "state_code": "MP"
+  },
+  {
+    "id": 132640,
+    "name": "Kumbhraj",
+    "state_code": "MP"
+  },
+  {
+    "id": 132741,
+    "name": "Lahar",
+    "state_code": "MP"
+  },
+  {
+    "id": 132746,
+    "name": "Lakhnadon",
+    "state_code": "MP"
+  },
+  {
+    "id": 132763,
+    "name": "Leteri",
+    "state_code": "MP"
+  },
+  {
+    "id": 132766,
+    "name": "Lodhikheda",
+    "state_code": "MP"
+  },
+  {
+    "id": 133054,
+    "name": "Machalpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 132814,
+    "name": "Madhogarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 132833,
+    "name": "Maheshwar",
+    "state_code": "MP"
+  },
+  {
+    "id": 132835,
+    "name": "Mahgawan",
+    "state_code": "MP"
+  },
+  {
+    "id": 132854,
+    "name": "Maihar",
+    "state_code": "MP"
+  },
+  {
+    "id": 132860,
+    "name": "Majholi",
+    "state_code": "MP"
+  },
+  {
+    "id": 132864,
+    "name": "Maksi",
+    "state_code": "MP"
+  },
+  {
+    "id": 132869,
+    "name": "Malhargarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 132930,
+    "name": "Manasa",
+    "state_code": "MP"
+  },
+  {
+    "id": 132931,
+    "name": "Manawar",
+    "state_code": "MP"
+  },
+  {
+    "id": 132894,
+    "name": "Mandideep",
+    "state_code": "MP"
+  },
+  {
+    "id": 132895,
+    "name": "Mandla",
+    "state_code": "MP"
+  },
+  {
+    "id": 133075,
+    "name": "Mandleshwar",
+    "state_code": "MP"
+  },
+  {
+    "id": 132897,
+    "name": "Mandsaur",
+    "state_code": "MP"
+  },
+  {
+    "id": 132907,
+    "name": "Mangawan",
+    "state_code": "MP"
+  },
+  {
+    "id": 133080,
+    "name": "Manpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 132943,
+    "name": "Mau",
+    "state_code": "MP"
+  },
+  {
+    "id": 132947,
+    "name": "Mauganj",
+    "state_code": "MP"
+  },
+  {
+    "id": 132973,
+    "name": "Mihona",
+    "state_code": "MP"
+  },
+  {
+    "id": 132983,
+    "name": "Mohgaon",
+    "state_code": "MP"
+  },
+  {
+    "id": 133003,
+    "name": "Morar",
+    "state_code": "MP"
+  },
+  {
+    "id": 132994,
+    "name": "Morena",
+    "state_code": "MP"
+  },
+  {
+    "id": 133022,
+    "name": "Multai",
+    "state_code": "MP"
+  },
+  {
+    "id": 133028,
+    "name": "Mundi",
+    "state_code": "MP"
+  },
+  {
+    "id": 133030,
+    "name": "Mungaoli",
+    "state_code": "MP"
+  },
+  {
+    "id": 133042,
+    "name": "Murwara",
+    "state_code": "MP"
+  },
+  {
+    "id": 133115,
+    "name": "Nagda",
+    "state_code": "MP"
+  },
+  {
+    "id": 133259,
+    "name": "Nagod",
+    "state_code": "MP"
+  },
+  {
+    "id": 133197,
+    "name": "Naigarhi",
+    "state_code": "MP"
+  },
+  {
+    "id": 133124,
+    "name": "Nainpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 133138,
+    "name": "Namli",
+    "state_code": "MP"
+  },
+  {
+    "id": 133155,
+    "name": "Naraini",
+    "state_code": "MP"
+  },
+  {
+    "id": 133276,
+    "name": "Narayangarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 133171,
+    "name": "Narsimhapur",
+    "state_code": "MP"
+  },
+  {
+    "id": 133172,
+    "name": "Narsinghgarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 133174,
+    "name": "Narwar",
+    "state_code": "MP"
+  },
+  {
+    "id": 133179,
+    "name": "Nasrullahganj",
+    "state_code": "MP"
+  },
+  {
+    "id": 133202,
+    "name": "Neemuch",
+    "state_code": "MP"
+  },
+  {
+    "id": 133207,
+    "name": "Nepanagar",
+    "state_code": "MP"
+  },
+  {
+    "id": 133304,
+    "name": "Orchha",
+    "state_code": "MP"
+  },
+  {
+    "id": 133308,
+    "name": "Pachmarhi",
+    "state_code": "MP"
+  },
+  {
+    "id": 133325,
+    "name": "Palera",
+    "state_code": "MP"
+  },
+  {
+    "id": 133530,
+    "name": "Pali",
+    "state_code": "MP"
+  },
+  {
+    "id": 133354,
+    "name": "Panagar",
+    "state_code": "MP"
+  },
+  {
+    "id": 133344,
+    "name": "Panara",
+    "state_code": "MP"
+  },
+  {
+    "id": 133348,
+    "name": "Pandhana",
+    "state_code": "MP"
+  },
+  {
+    "id": 133538,
+    "name": "Pandhurna",
+    "state_code": "MP"
+  },
+  {
+    "id": 133351,
+    "name": "Panna",
+    "state_code": "MP"
+  },
+  {
+    "id": 133542,
+    "name": "Pansemal",
+    "state_code": "MP"
+  },
+  {
+    "id": 133371,
+    "name": "Parasia",
+    "state_code": "MP"
+  },
+  {
+    "id": 133555,
+    "name": "Patan",
+    "state_code": "MP"
+  },
+  {
+    "id": 133381,
+    "name": "Patharia",
+    "state_code": "MP"
+  },
+  {
+    "id": 133396,
+    "name": "Pawai",
+    "state_code": "MP"
+  },
+  {
+    "id": 133430,
+    "name": "Petlawad",
+    "state_code": "MP"
+  },
+  {
+    "id": 133454,
+    "name": "Piploda",
+    "state_code": "MP"
+  },
+  {
+    "id": 133462,
+    "name": "Pithampur",
+    "state_code": "MP"
+  },
+  {
+    "id": 133481,
+    "name": "Porsa",
+    "state_code": "MP"
+  },
+  {
+    "id": 133508,
+    "name": "Punasa",
+    "state_code": "MP"
+  },
+  {
+    "id": 133660,
+    "name": "Raghogarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 133661,
+    "name": "Rahatgarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 133591,
+    "name": "Raisen",
+    "state_code": "MP"
+  },
+  {
+    "id": 133675,
+    "name": "Rajgarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 133680,
+    "name": "Rajnagar",
+    "state_code": "MP"
+  },
+  {
+    "id": 133595,
+    "name": "Rajpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 133709,
+    "name": "Rampura",
+    "state_code": "MP"
+  },
+  {
+    "id": 133717,
+    "name": "Ranapur",
+    "state_code": "MP"
+  },
+  {
+    "id": 133615,
+    "name": "Ratangarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 133618,
+    "name": "Ratlam",
+    "state_code": "MP"
+  },
+  {
+    "id": 133623,
+    "name": "Rehli",
+    "state_code": "MP"
+  },
+  {
+    "id": 133624,
+    "name": "Rehti",
+    "state_code": "MP"
+  },
+  {
+    "id": 133633,
+    "name": "Rewa",
+    "state_code": "MP"
+  },
+  {
+    "id": 133738,
+    "name": "Sabalgarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 134061,
+    "name": "Sagar",
+    "state_code": "MP"
+  },
+  {
+    "id": 133757,
+    "name": "Sailana",
+    "state_code": "MP"
+  },
+  {
+    "id": 133796,
+    "name": "Sanawad",
+    "state_code": "MP"
+  },
+  {
+    "id": 134070,
+    "name": "Sanchi",
+    "state_code": "MP"
+  },
+  {
+    "id": 134075,
+    "name": "Sanwer",
+    "state_code": "MP"
+  },
+  {
+    "id": 134078,
+    "name": "Sarangpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 133820,
+    "name": "Satna",
+    "state_code": "MP"
+  },
+  {
+    "id": 133824,
+    "name": "Satwas",
+    "state_code": "MP"
+  },
+  {
+    "id": 133826,
+    "name": "Saugor",
+    "state_code": "MP"
+  },
+  {
+    "id": 133829,
+    "name": "Sausar",
+    "state_code": "MP"
+  },
+  {
+    "id": 133835,
+    "name": "Sehore",
+    "state_code": "MP"
+  },
+  {
+    "id": 133838,
+    "name": "Sendhwa",
+    "state_code": "MP"
+  },
+  {
+    "id": 133840,
+    "name": "Seondha",
+    "state_code": "MP"
+  },
+  {
+    "id": 133842,
+    "name": "Seoni",
+    "state_code": "MP"
+  },
+  {
+    "id": 133843,
+    "name": "Seoni Malwa",
+    "state_code": "MP"
+  },
+  {
+    "id": 133853,
+    "name": "Shahdol",
+    "state_code": "MP"
+  },
+  {
+    "id": 133893,
+    "name": "Shahgarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 133899,
+    "name": "Shahpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 133904,
+    "name": "Shahpura",
+    "state_code": "MP"
+  },
+  {
+    "id": 133910,
+    "name": "Shajapur",
+    "state_code": "MP"
+  },
+  {
+    "id": 133912,
+    "name": "Shamgarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 133861,
+    "name": "Sheopur",
+    "state_code": "MP"
+  },
+  {
+    "id": 133880,
+    "name": "Shivpuri",
+    "state_code": "MP"
+  },
+  {
+    "id": 133888,
+    "name": "Shujalpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 133922,
+    "name": "Sidhi",
+    "state_code": "MP"
+  },
+  {
+    "id": 133926,
+    "name": "Sihora",
+    "state_code": "MP"
+  },
+  {
+    "id": 133938,
+    "name": "Simaria",
+    "state_code": "MP"
+  },
+  {
+    "id": 133947,
+    "name": "Singoli",
+    "state_code": "MP"
+  },
+  {
+    "id": 133948,
+    "name": "Singrauli",
+    "state_code": "MP"
+  },
+  {
+    "id": 133956,
+    "name": "Sirmaur",
+    "state_code": "MP"
+  },
+  {
+    "id": 133959,
+    "name": "Sironj",
+    "state_code": "MP"
+  },
+  {
+    "id": 134090,
+    "name": "Sitamau",
+    "state_code": "MP"
+  },
+  {
+    "id": 133981,
+    "name": "Sohagi",
+    "state_code": "MP"
+  },
+  {
+    "id": 133982,
+    "name": "Sohagpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 134039,
+    "name": "Sultanpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 134055,
+    "name": "Susner",
+    "state_code": "MP"
+  },
+  {
+    "id": 134230,
+    "name": "Tal",
+    "state_code": "MP"
+  },
+  {
+    "id": 134102,
+    "name": "Talen",
+    "state_code": "MP"
+  },
+  {
+    "id": 134119,
+    "name": "Tarana",
+    "state_code": "MP"
+  },
+  {
+    "id": 134124,
+    "name": "Tekanpur",
+    "state_code": "MP"
+  },
+  {
+    "id": 134130,
+    "name": "Tendukheda",
+    "state_code": "MP"
+  },
+  {
+    "id": 134132,
+    "name": "Teonthar",
+    "state_code": "MP"
+  },
+  {
+    "id": 134137,
+    "name": "Thandla",
+    "state_code": "MP"
+  },
+  {
+    "id": 134244,
+    "name": "Tikamgarh",
+    "state_code": "MP"
+  },
+  {
+    "id": 134177,
+    "name": "Tirodi",
+    "state_code": "MP"
+  },
+  {
+    "id": 134251,
+    "name": "Udaipura",
+    "state_code": "MP"
+  },
+  {
+    "id": 134263,
+    "name": "Ujjain",
+    "state_code": "MP"
+  },
+  {
+    "id": 134266,
+    "name": "Ukwa",
+    "state_code": "MP"
+  },
+  {
+    "id": 134270,
+    "name": "Umaria",
+    "state_code": "MP"
+  },
+  {
+    "id": 134276,
+    "name": "Umri",
+    "state_code": "MP"
+  },
+  {
+    "id": 134282,
+    "name": "Unhel",
+    "state_code": "MP"
+  },
+  {
+    "id": 134354,
+    "name": "Vidisha",
+    "state_code": "MP"
+  },
+  {
+    "id": 134418,
+    "name": "Waraseoni",
+    "state_code": "MP"
+  },
+  {
+    "id": 57589,
+    "name": "Achalpur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147667,
+    "name": "Adawad",
+    "state_code": "MH"
+  },
+  {
+    "id": 147668,
+    "name": "Agar Panchaitan",
+    "state_code": "MH"
+  },
+  {
+    "id": 147669,
+    "name": "Aheri",
+    "state_code": "MH"
+  },
+  {
+    "id": 57604,
+    "name": "Ahmadpur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147670,
+    "name": "Ahmednagar",
+    "state_code": "MH"
+  },
+  {
+    "id": 57609,
+    "name": "Airoli",
+    "state_code": "MH"
+  },
+  {
+    "id": 57617,
+    "name": "Ajara",
+    "state_code": "MH"
+  },
+  {
+    "id": 57618,
+    "name": "Akalkot",
+    "state_code": "MH"
+  },
+  {
+    "id": 147672,
+    "name": "Akluj",
+    "state_code": "MH"
+  },
+  {
+    "id": 57627,
+    "name": "Akola",
+    "state_code": "MH"
+  },
+  {
+    "id": 147673,
+    "name": "Akolner",
+    "state_code": "MH"
+  },
+  {
+    "id": 57628,
+    "name": "Akot",
+    "state_code": "MH"
+  },
+  {
+    "id": 147674,
+    "name": "Akrani",
+    "state_code": "MH"
+  },
+  {
+    "id": 57633,
+    "name": "Alandi",
+    "state_code": "MH"
+  },
+  {
+    "id": 147675,
+    "name": "Ale",
+    "state_code": "MH"
+  },
+  {
+    "id": 57652,
+    "name": "Alibag",
+    "state_code": "MH"
+  },
+  {
+    "id": 147676,
+    "name": "Alkuti",
+    "state_code": "MH"
+  },
+  {
+    "id": 57642,
+    "name": "Allapalli",
+    "state_code": "MH"
+  },
+  {
+    "id": 57657,
+    "name": "Amalner",
+    "state_code": "MH"
+  },
+  {
+    "id": 57660,
+    "name": "Amarnath",
+    "state_code": "MH"
+  },
+  {
+    "id": 57665,
+    "name": "Ambad",
+    "state_code": "MH"
+  },
+  {
+    "id": 57674,
+    "name": "Ambajogai",
+    "state_code": "MH"
+  },
+  {
+    "id": 147678,
+    "name": "Ambegaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147677,
+    "name": "Ambernath",
+    "state_code": "MH"
+  },
+  {
+    "id": 147679,
+    "name": "Amgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 57689,
+    "name": "Amravati",
+    "state_code": "MH"
+  },
+  {
+    "id": 147680,
+    "name": "Andheri",
+    "state_code": "MH"
+  },
+  {
+    "id": 147681,
+    "name": "Andura",
+    "state_code": "MH"
+  },
+  {
+    "id": 57707,
+    "name": "Anjangaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147682,
+    "name": "Anjarle",
+    "state_code": "MH"
+  },
+  {
+    "id": 57716,
+    "name": "Anshing",
+    "state_code": "MH"
+  },
+  {
+    "id": 147683,
+    "name": "Arag",
+    "state_code": "MH"
+  },
+  {
+    "id": 134461,
+    "name": "Arangaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147684,
+    "name": "Ardhapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147685,
+    "name": "Argaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 57741,
+    "name": "Artist Village",
+    "state_code": "MH"
+  },
+  {
+    "id": 134463,
+    "name": "Arvi",
+    "state_code": "MH"
+  },
+  {
+    "id": 57751,
+    "name": "Ashta",
+    "state_code": "MH"
+  },
+  {
+    "id": 57753,
+    "name": "Ashti",
+    "state_code": "MH"
+  },
+  {
+    "id": 147686,
+    "name": "Asoda",
+    "state_code": "MH"
+  },
+  {
+    "id": 147687,
+    "name": "Assaye",
+    "state_code": "MH"
+  },
+  {
+    "id": 147688,
+    "name": "Astagaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147689,
+    "name": "Aundh Satara",
+    "state_code": "MH"
+  },
+  {
+    "id": 57765,
+    "name": "Aurangabad",
+    "state_code": "MH"
+  },
+  {
+    "id": 57770,
+    "name": "Ausa",
+    "state_code": "MH"
+  },
+  {
+    "id": 57792,
+    "name": "Badlapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147690,
+    "name": "Badnapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147691,
+    "name": "Badnera",
+    "state_code": "MH"
+  },
+  {
+    "id": 147692,
+    "name": "Bagewadi",
+    "state_code": "MH"
+  },
+  {
+    "id": 58121,
+    "name": "Balapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147693,
+    "name": "Balapur Akola district",
+    "state_code": "MH"
+  },
+  {
+    "id": 57829,
+    "name": "Ballalpur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147694,
+    "name": "Ballard Estate",
+    "state_code": "MH"
+  },
+  {
+    "id": 147695,
+    "name": "Ballarpur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147696,
+    "name": "Banda Maharashtra",
+    "state_code": "MH"
+  },
+  {
+    "id": 147697,
+    "name": "Bandra",
+    "state_code": "MH"
+  },
+  {
+    "id": 147698,
+    "name": "Baner",
+    "state_code": "MH"
+  },
+  {
+    "id": 147699,
+    "name": "Bankot",
+    "state_code": "MH"
+  },
+  {
+    "id": 58146,
+    "name": "Baramati",
+    "state_code": "MH"
+  },
+  {
+    "id": 58144,
+    "name": "Barsi",
+    "state_code": "MH"
+  },
+  {
+    "id": 57897,
+    "name": "Basmat",
+    "state_code": "MH"
+  },
+  {
+    "id": 147701,
+    "name": "Bavdhan",
+    "state_code": "MH"
+  },
+  {
+    "id": 147702,
+    "name": "Bawanbir",
+    "state_code": "MH"
+  },
+  {
+    "id": 57912,
+    "name": "Beed",
+    "state_code": "MH"
+  },
+  {
+    "id": 147703,
+    "name": "Bhadgaon Maharashtra",
+    "state_code": "MH"
+  },
+  {
+    "id": 57961,
+    "name": "Bhandara",
+    "state_code": "MH"
+  },
+  {
+    "id": 147704,
+    "name": "Bhandardara",
+    "state_code": "MH"
+  },
+  {
+    "id": 147705,
+    "name": "Bhandup",
+    "state_code": "MH"
+  },
+  {
+    "id": 57978,
+    "name": "Bhayandar",
+    "state_code": "MH"
+  },
+  {
+    "id": 57979,
+    "name": "Bhigvan",
+    "state_code": "MH"
+  },
+  {
+    "id": 57987,
+    "name": "Bhiwandi",
+    "state_code": "MH"
+  },
+  {
+    "id": 147706,
+    "name": "Bhiwapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147707,
+    "name": "Bhokar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147708,
+    "name": "Bhokardan",
+    "state_code": "MH"
+  },
+  {
+    "id": 58024,
+    "name": "Bhoom",
+    "state_code": "MH"
+  },
+  {
+    "id": 57997,
+    "name": "Bhor",
+    "state_code": "MH"
+  },
+  {
+    "id": 58001,
+    "name": "Bhudgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147710,
+    "name": "Bhugaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 58005,
+    "name": "Bhusaval",
+    "state_code": "MH"
+  },
+  {
+    "id": 147712,
+    "name": "Bijur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147713,
+    "name": "Bilashi",
+    "state_code": "MH"
+  },
+  {
+    "id": 58047,
+    "name": "Biloli",
+    "state_code": "MH"
+  },
+  {
+    "id": 58074,
+    "name": "Boisar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147714,
+    "name": "Borgaon Manju",
+    "state_code": "MH"
+  },
+  {
+    "id": 147715,
+    "name": "Borivali",
+    "state_code": "MH"
+  },
+  {
+    "id": 147716,
+    "name": "Brahmapuri",
+    "state_code": "MH"
+  },
+  {
+    "id": 147717,
+    "name": "Breach Candy",
+    "state_code": "MH"
+  },
+  {
+    "id": 58094,
+    "name": "Buldana",
+    "state_code": "MH"
+  },
+  {
+    "id": 147719,
+    "name": "Byculla",
+    "state_code": "MH"
+  },
+  {
+    "id": 131589,
+    "name": "Chakan",
+    "state_code": "MH"
+  },
+  {
+    "id": 147720,
+    "name": "Chakur",
+    "state_code": "MH"
+  },
+  {
+    "id": 131592,
+    "name": "Chalisgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 131596,
+    "name": "Chanda",
+    "state_code": "MH"
+  },
+  {
+    "id": 147721,
+    "name": "Chandgad",
+    "state_code": "MH"
+  },
+  {
+    "id": 131599,
+    "name": "Chandor",
+    "state_code": "MH"
+  },
+  {
+    "id": 58192,
+    "name": "Chandrapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 131601,
+    "name": "Chandur",
+    "state_code": "MH"
+  },
+  {
+    "id": 131603,
+    "name": "Chandur Bazar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147722,
+    "name": "Chausala",
+    "state_code": "MH"
+  },
+  {
+    "id": 147723,
+    "name": "Chembur",
+    "state_code": "MH"
+  },
+  {
+    "id": 131544,
+    "name": "Chicholi",
+    "state_code": "MH"
+  },
+  {
+    "id": 147724,
+    "name": "Chichondi Patil",
+    "state_code": "MH"
+  },
+  {
+    "id": 131549,
+    "name": "Chikhli (Buldhana)",
+    "state_code": "MH"
+  },
+  {
+    "id": 147725,
+    "name": "Chikhli (Jalna)",
+    "state_code": "MH"
+  },
+  {
+    "id": 147726,
+    "name": "Chimur",
+    "state_code": "MH"
+  },
+  {
+    "id": 131558,
+    "name": "Chinchani",
+    "state_code": "MH"
+  },
+  {
+    "id": 147727,
+    "name": "Chinchpokli",
+    "state_code": "MH"
+  },
+  {
+    "id": 131567,
+    "name": "Chiplun",
+    "state_code": "MH"
+  },
+  {
+    "id": 131580,
+    "name": "Chopda",
+    "state_code": "MH"
+  },
+  {
+    "id": 147728,
+    "name": "Colaba",
+    "state_code": "MH"
+  },
+  {
+    "id": 131805,
+    "name": "Dabhol",
+    "state_code": "MH"
+  },
+  {
+    "id": 147729,
+    "name": "Daddi",
+    "state_code": "MH"
+  },
+  {
+    "id": 131807,
+    "name": "Dahanu",
+    "state_code": "MH"
+  },
+  {
+    "id": 147730,
+    "name": "Dahivel",
+    "state_code": "MH"
+  },
+  {
+    "id": 147731,
+    "name": "Dapoli",
+    "state_code": "MH"
+  },
+  {
+    "id": 131810,
+    "name": "Darwha",
+    "state_code": "MH"
+  },
+  {
+    "id": 131659,
+    "name": "Daryapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 131663,
+    "name": "Dattapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 131666,
+    "name": "Daulatabad",
+    "state_code": "MH"
+  },
+  {
+    "id": 131667,
+    "name": "Daund",
+    "state_code": "MH"
+  },
+  {
+    "id": 147732,
+    "name": "Deccan Gymkhana",
+    "state_code": "MH"
+  },
+  {
+    "id": 147733,
+    "name": "Deglur",
+    "state_code": "MH"
+  },
+  {
+    "id": 131678,
+    "name": "Dehu",
+    "state_code": "MH"
+  },
+  {
+    "id": 131688,
+    "name": "Deolali",
+    "state_code": "MH"
+  },
+  {
+    "id": 147734,
+    "name": "Deolapar",
+    "state_code": "MH"
+  },
+  {
+    "id": 131686,
+    "name": "Deoli",
+    "state_code": "MH"
+  },
+  {
+    "id": 147735,
+    "name": "Deoni",
+    "state_code": "MH"
+  },
+  {
+    "id": 131709,
+    "name": "Deulgaon Raja",
+    "state_code": "MH"
+  },
+  {
+    "id": 147736,
+    "name": "Devrukh",
+    "state_code": "MH"
+  },
+  {
+    "id": 131722,
+    "name": "Dharangaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147737,
+    "name": "Dharavi",
+    "state_code": "MH"
+  },
+  {
+    "id": 131728,
+    "name": "Dharmabad",
+    "state_code": "MH"
+  },
+  {
+    "id": 131758,
+    "name": "Dharur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147738,
+    "name": "Dhawalpuri",
+    "state_code": "MH"
+  },
+  {
+    "id": 131746,
+    "name": "Dhule",
+    "state_code": "MH"
+  },
+  {
+    "id": 131759,
+    "name": "Dhulia",
+    "state_code": "MH"
+  },
+  {
+    "id": 147739,
+    "name": "Dighori",
+    "state_code": "MH"
+  },
+  {
+    "id": 131815,
+    "name": "Diglur",
+    "state_code": "MH"
+  },
+  {
+    "id": 131768,
+    "name": "Digras",
+    "state_code": "MH"
+  },
+  {
+    "id": 147740,
+    "name": "Dindori Maharashtra",
+    "state_code": "MH"
+  },
+  {
+    "id": 147741,
+    "name": "Diveagar",
+    "state_code": "MH"
+  },
+  {
+    "id": 131785,
+    "name": "Dombivli",
+    "state_code": "MH"
+  },
+  {
+    "id": 131786,
+    "name": "Dondaicha",
+    "state_code": "MH"
+  },
+  {
+    "id": 147742,
+    "name": "Dongri",
+    "state_code": "MH"
+  },
+  {
+    "id": 131792,
+    "name": "Dudhani",
+    "state_code": "MH"
+  },
+  {
+    "id": 131802,
+    "name": "Durgapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147743,
+    "name": "Durgapur Chandrapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 131838,
+    "name": "Erandol",
+    "state_code": "MH"
+  },
+  {
+    "id": 131850,
+    "name": "Faizpur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147744,
+    "name": "Fort",
+    "state_code": "MH"
+  },
+  {
+    "id": 131886,
+    "name": "Gadchiroli",
+    "state_code": "MH"
+  },
+  {
+    "id": 131889,
+    "name": "Gadhinglaj",
+    "state_code": "MH"
+  },
+  {
+    "id": 131907,
+    "name": "Gangakher",
+    "state_code": "MH"
+  },
+  {
+    "id": 131910,
+    "name": "Gangapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147745,
+    "name": "Ganpatipule",
+    "state_code": "MH"
+  },
+  {
+    "id": 131934,
+    "name": "Gevrai",
+    "state_code": "MH"
+  },
+  {
+    "id": 147746,
+    "name": "Ghargaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 131951,
+    "name": "Ghatanji",
+    "state_code": "MH"
+  },
+  {
+    "id": 147747,
+    "name": "Ghatkopar",
+    "state_code": "MH"
+  },
+  {
+    "id": 131947,
+    "name": "Ghoti Budrukh",
+    "state_code": "MH"
+  },
+  {
+    "id": 131948,
+    "name": "Ghugus",
+    "state_code": "MH"
+  },
+  {
+    "id": 147748,
+    "name": "Girgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147749,
+    "name": "Gondia",
+    "state_code": "MH"
+  },
+  {
+    "id": 147750,
+    "name": "Gorai",
+    "state_code": "MH"
+  },
+  {
+    "id": 131994,
+    "name": "Goregaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 132014,
+    "name": "Guhagar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147751,
+    "name": "Hadapsar Pune",
+    "state_code": "MH"
+  },
+  {
+    "id": 132054,
+    "name": "Hadgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147752,
+    "name": "Halkarni",
+    "state_code": "MH"
+  },
+  {
+    "id": 147753,
+    "name": "Harangul",
+    "state_code": "MH"
+  },
+  {
+    "id": 132078,
+    "name": "Harnai",
+    "state_code": "MH"
+  },
+  {
+    "id": 147754,
+    "name": "Helwak",
+    "state_code": "MH"
+  },
+  {
+    "id": 132100,
+    "name": "Hinganghat",
+    "state_code": "MH"
+  },
+  {
+    "id": 132101,
+    "name": "Hingoli",
+    "state_code": "MH"
+  },
+  {
+    "id": 147755,
+    "name": "Hirapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 132149,
+    "name": "Hirapur Hamesha",
+    "state_code": "MH"
+  },
+  {
+    "id": 147756,
+    "name": "Hotgi",
+    "state_code": "MH"
+  },
+  {
+    "id": 132150,
+    "name": "Ichalkaranji",
+    "state_code": "MH"
+  },
+  {
+    "id": 132155,
+    "name": "Igatpuri",
+    "state_code": "MH"
+  },
+  {
+    "id": 132168,
+    "name": "Indapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 132205,
+    "name": "Jaisingpur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147757,
+    "name": "Jaitapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147758,
+    "name": "Jakhangaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 132214,
+    "name": "Jalgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 132215,
+    "name": "Jalgaon Jamod",
+    "state_code": "MH"
+  },
+  {
+    "id": 147759,
+    "name": "Jalkot",
+    "state_code": "MH"
+  },
+  {
+    "id": 132216,
+    "name": "Jalna",
+    "state_code": "MH"
+  },
+  {
+    "id": 147760,
+    "name": "Jamkhed",
+    "state_code": "MH"
+  },
+  {
+    "id": 147761,
+    "name": "Jamod",
+    "state_code": "MH"
+  },
+  {
+    "id": 147762,
+    "name": "Janephal",
+    "state_code": "MH"
+  },
+  {
+    "id": 147763,
+    "name": "Jaoli",
+    "state_code": "MH"
+  },
+  {
+    "id": 147764,
+    "name": "Jat Sangli",
+    "state_code": "MH"
+  },
+  {
+    "id": 147765,
+    "name": "Jategaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 132254,
+    "name": "Jawhar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147766,
+    "name": "Jaysingpur",
+    "state_code": "MH"
+  },
+  {
+    "id": 132260,
+    "name": "Jejuri",
+    "state_code": "MH"
+  },
+  {
+    "id": 132282,
+    "name": "Jintur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147767,
+    "name": "Jogeshwari",
+    "state_code": "MH"
+  },
+  {
+    "id": 147768,
+    "name": "Juhu",
+    "state_code": "MH"
+  },
+  {
+    "id": 132301,
+    "name": "Junnar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147769,
+    "name": "Kachurwahi",
+    "state_code": "MH"
+  },
+  {
+    "id": 147770,
+    "name": "Kadegaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147771,
+    "name": "Kadus",
+    "state_code": "MH"
+  },
+  {
+    "id": 132677,
+    "name": "Kagal",
+    "state_code": "MH"
+  },
+  {
+    "id": 147772,
+    "name": "Kaij",
+    "state_code": "MH"
+  },
+  {
+    "id": 132345,
+    "name": "Kalamb",
+    "state_code": "MH"
+  },
+  {
+    "id": 147773,
+    "name": "Kalamb Osmanabad",
+    "state_code": "MH"
+  },
+  {
+    "id": 147774,
+    "name": "Kalamboli",
+    "state_code": "MH"
+  },
+  {
+    "id": 132346,
+    "name": "Kalamnuri",
+    "state_code": "MH"
+  },
+  {
+    "id": 132348,
+    "name": "Kalas",
+    "state_code": "MH"
+  },
+  {
+    "id": 147775,
+    "name": "Kali(DK)",
+    "state_code": "MH"
+  },
+  {
+    "id": 132355,
+    "name": "Kalmeshwar",
+    "state_code": "MH"
+  },
+  {
+    "id": 132684,
+    "name": "Kalundri",
+    "state_code": "MH"
+  },
+  {
+    "id": 132359,
+    "name": "Kalyan",
+    "state_code": "MH"
+  },
+  {
+    "id": 147776,
+    "name": "Kalyani Nagar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147777,
+    "name": "Kamargaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147778,
+    "name": "Kamatgi",
+    "state_code": "MH"
+  },
+  {
+    "id": 147779,
+    "name": "Kamptee",
+    "state_code": "MH"
+  },
+  {
+    "id": 132700,
+    "name": "Kandri",
+    "state_code": "MH"
+  },
+  {
+    "id": 132375,
+    "name": "Kankauli",
+    "state_code": "MH"
+  },
+  {
+    "id": 147780,
+    "name": "Kankavli",
+    "state_code": "MH"
+  },
+  {
+    "id": 132377,
+    "name": "Kannad",
+    "state_code": "MH"
+  },
+  {
+    "id": 132412,
+    "name": "Karad",
+    "state_code": "MH"
+  },
+  {
+    "id": 147781,
+    "name": "Karajagi",
+    "state_code": "MH"
+  },
+  {
+    "id": 132717,
+    "name": "Karanja",
+    "state_code": "MH"
+  },
+  {
+    "id": 147782,
+    "name": "Karanja Lad",
+    "state_code": "MH"
+  },
+  {
+    "id": 132403,
+    "name": "Karjat",
+    "state_code": "MH"
+  },
+  {
+    "id": 147783,
+    "name": "Karkamb",
+    "state_code": "MH"
+  },
+  {
+    "id": 132404,
+    "name": "Karmala",
+    "state_code": "MH"
+  },
+  {
+    "id": 147784,
+    "name": "Kasara",
+    "state_code": "MH"
+  },
+  {
+    "id": 147785,
+    "name": "Kasoda",
+    "state_code": "MH"
+  },
+  {
+    "id": 132724,
+    "name": "Kati",
+    "state_code": "MH"
+  },
+  {
+    "id": 132725,
+    "name": "Katol",
+    "state_code": "MH"
+  },
+  {
+    "id": 147786,
+    "name": "Katral",
+    "state_code": "MH"
+  },
+  {
+    "id": 132450,
+    "name": "Khadki",
+    "state_code": "MH"
+  },
+  {
+    "id": 147787,
+    "name": "Khalapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147788,
+    "name": "Khallar",
+    "state_code": "MH"
+  },
+  {
+    "id": 132513,
+    "name": "Khamgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147789,
+    "name": "Khanapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147790,
+    "name": "Khandala",
+    "state_code": "MH"
+  },
+  {
+    "id": 147791,
+    "name": "Khangaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 132517,
+    "name": "Khapa",
+    "state_code": "MH"
+  },
+  {
+    "id": 132471,
+    "name": "Kharakvasla",
+    "state_code": "MH"
+  },
+  {
+    "id": 147792,
+    "name": "Kharda",
+    "state_code": "MH"
+  },
+  {
+    "id": 147793,
+    "name": "Kharghar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147794,
+    "name": "Kharsundi",
+    "state_code": "MH"
+  },
+  {
+    "id": 132487,
+    "name": "Khed",
+    "state_code": "MH"
+  },
+  {
+    "id": 132495,
+    "name": "Khetia",
+    "state_code": "MH"
+  },
+  {
+    "id": 147796,
+    "name": "Khoni",
+    "state_code": "MH"
+  },
+  {
+    "id": 132500,
+    "name": "Khopoli",
+    "state_code": "MH"
+  },
+  {
+    "id": 132505,
+    "name": "Khuldabad",
+    "state_code": "MH"
+  },
+  {
+    "id": 132524,
+    "name": "Kinwat",
+    "state_code": "MH"
+  },
+  {
+    "id": 132543,
+    "name": "Kodoli",
+    "state_code": "MH"
+  },
+  {
+    "id": 132556,
+    "name": "Kolhapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 132566,
+    "name": "Kondalwadi",
+    "state_code": "MH"
+  },
+  {
+    "id": 147797,
+    "name": "Kondhali",
+    "state_code": "MH"
+  },
+  {
+    "id": 147798,
+    "name": "Kopar Khairane",
+    "state_code": "MH"
+  },
+  {
+    "id": 132572,
+    "name": "Kopargaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147799,
+    "name": "Kopela",
+    "state_code": "MH"
+  },
+  {
+    "id": 132586,
+    "name": "Koradi",
+    "state_code": "MH"
+  },
+  {
+    "id": 132582,
+    "name": "Koregaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 132618,
+    "name": "Koynanagar",
+    "state_code": "MH"
+  },
+  {
+    "id": 132629,
+    "name": "Kudal",
+    "state_code": "MH"
+  },
+  {
+    "id": 147800,
+    "name": "Kuhi",
+    "state_code": "MH"
+  },
+  {
+    "id": 132656,
+    "name": "Kurandvad",
+    "state_code": "MH"
+  },
+  {
+    "id": 147801,
+    "name": "Kurankhed",
+    "state_code": "MH"
+  },
+  {
+    "id": 132657,
+    "name": "Kurduvadi",
+    "state_code": "MH"
+  },
+  {
+    "id": 147802,
+    "name": "Kusumba",
+    "state_code": "MH"
+  },
+  {
+    "id": 147803,
+    "name": "Lakhandur",
+    "state_code": "MH"
+  },
+  {
+    "id": 132799,
+    "name": "Lanja",
+    "state_code": "MH"
+  },
+  {
+    "id": 132800,
+    "name": "Lasalgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 132759,
+    "name": "Latur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147804,
+    "name": "Lavasa",
+    "state_code": "MH"
+  },
+  {
+    "id": 132770,
+    "name": "Lohogaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 132776,
+    "name": "Lonar",
+    "state_code": "MH"
+  },
+  {
+    "id": 132773,
+    "name": "Lonavla",
+    "state_code": "MH"
+  },
+  {
+    "id": 132844,
+    "name": "Mahabaleshwar",
+    "state_code": "MH"
+  },
+  {
+    "id": 132846,
+    "name": "Mahad",
+    "state_code": "MH"
+  },
+  {
+    "id": 147805,
+    "name": "Mahape",
+    "state_code": "MH"
+  },
+  {
+    "id": 147806,
+    "name": "Mahim",
+    "state_code": "MH"
+  },
+  {
+    "id": 132856,
+    "name": "Maindargi",
+    "state_code": "MH"
+  },
+  {
+    "id": 133062,
+    "name": "Majalgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 133063,
+    "name": "Makhjan",
+    "state_code": "MH"
+  },
+  {
+    "id": 147807,
+    "name": "Malabar Hill",
+    "state_code": "MH"
+  },
+  {
+    "id": 147808,
+    "name": "Malad",
+    "state_code": "MH"
+  },
+  {
+    "id": 133065,
+    "name": "Malegaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 132872,
+    "name": "Malkapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 133070,
+    "name": "Malvan",
+    "state_code": "MH"
+  },
+  {
+    "id": 132886,
+    "name": "Manchar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147809,
+    "name": "Mandangad",
+    "state_code": "MH"
+  },
+  {
+    "id": 147810,
+    "name": "Mandhal",
+    "state_code": "MH"
+  },
+  {
+    "id": 147811,
+    "name": "Mandwa",
+    "state_code": "MH"
+  },
+  {
+    "id": 147812,
+    "name": "Mangaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 132909,
+    "name": "Mangrul Pir",
+    "state_code": "MH"
+  },
+  {
+    "id": 147813,
+    "name": "Manjlegaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147814,
+    "name": "Mankeshwar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147815,
+    "name": "Mankhurd",
+    "state_code": "MH"
+  },
+  {
+    "id": 132918,
+    "name": "Manmad",
+    "state_code": "MH"
+  },
+  {
+    "id": 132924,
+    "name": "Manor",
+    "state_code": "MH"
+  },
+  {
+    "id": 132926,
+    "name": "Mansar",
+    "state_code": "MH"
+  },
+  {
+    "id": 133084,
+    "name": "Manwat",
+    "state_code": "MH"
+  },
+  {
+    "id": 147817,
+    "name": "Maregaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147818,
+    "name": "Mastiholi",
+    "state_code": "MH"
+  },
+  {
+    "id": 147819,
+    "name": "Masur India",
+    "state_code": "MH"
+  },
+  {
+    "id": 133090,
+    "name": "Matheran",
+    "state_code": "MH"
+  },
+  {
+    "id": 147820,
+    "name": "Matunga",
+    "state_code": "MH"
+  },
+  {
+    "id": 147821,
+    "name": "Mazagaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 132961,
+    "name": "Mehekar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147822,
+    "name": "Mehergaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147823,
+    "name": "Mehkar",
+    "state_code": "MH"
+  },
+  {
+    "id": 132971,
+    "name": "Mhasla",
+    "state_code": "MH"
+  },
+  {
+    "id": 132972,
+    "name": "Mhasvad",
+    "state_code": "MH"
+  },
+  {
+    "id": 147824,
+    "name": "Miraj",
+    "state_code": "MH"
+  },
+  {
+    "id": 147825,
+    "name": "Mohadi",
+    "state_code": "MH"
+  },
+  {
+    "id": 147826,
+    "name": "Mohol",
+    "state_code": "MH"
+  },
+  {
+    "id": 132985,
+    "name": "Mohpa",
+    "state_code": "MH"
+  },
+  {
+    "id": 147827,
+    "name": "Mokhada taluka",
+    "state_code": "MH"
+  },
+  {
+    "id": 147828,
+    "name": "Mora Maharashtra",
+    "state_code": "MH"
+  },
+  {
+    "id": 132992,
+    "name": "Moram",
+    "state_code": "MH"
+  },
+  {
+    "id": 132999,
+    "name": "Morsi",
+    "state_code": "MH"
+  },
+  {
+    "id": 133006,
+    "name": "Mowad",
+    "state_code": "MH"
+  },
+  {
+    "id": 133012,
+    "name": "Mudkhed",
+    "state_code": "MH"
+  },
+  {
+    "id": 133018,
+    "name": "Mukher",
+    "state_code": "MH"
+  },
+  {
+    "id": 133099,
+    "name": "Mul",
+    "state_code": "MH"
+  },
+  {
+    "id": 147829,
+    "name": "Mulher",
+    "state_code": "MH"
+  },
+  {
+    "id": 147830,
+    "name": "Mulund",
+    "state_code": "MH"
+  },
+  {
+    "id": 133024,
+    "name": "Mumbai",
+    "state_code": "MH"
+  },
+  {
+    "id": 133025,
+    "name": "Mumbai Suburban",
+    "state_code": "MH"
+  },
+  {
+    "id": 133035,
+    "name": "Murbad",
+    "state_code": "MH"
+  },
+  {
+    "id": 133036,
+    "name": "Murgud",
+    "state_code": "MH"
+  },
+  {
+    "id": 133039,
+    "name": "Murtajapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 133040,
+    "name": "Murud (Raigad)",
+    "state_code": "MH"
+  },
+  {
+    "id": 147831,
+    "name": "Murud (Ratnagiri)",
+    "state_code": "MH"
+  },
+  {
+    "id": 147832,
+    "name": "Murum",
+    "state_code": "MH"
+  },
+  {
+    "id": 147833,
+    "name": "Nadgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147834,
+    "name": "Nagapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 133260,
+    "name": "Nagothana",
+    "state_code": "MH"
+  },
+  {
+    "id": 133116,
+    "name": "Nagpur",
+    "state_code": "MH"
+  },
+  {
+    "id": 133117,
+    "name": "Nagpur Division",
+    "state_code": "MH"
+  },
+  {
+    "id": 147835,
+    "name": "Nala Sopara",
+    "state_code": "MH"
+  },
+  {
+    "id": 133131,
+    "name": "Naldurg",
+    "state_code": "MH"
+  },
+  {
+    "id": 147836,
+    "name": "Nalegaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147837,
+    "name": "Nampur",
+    "state_code": "MH"
+  },
+  {
+    "id": 133141,
+    "name": "Nanded",
+    "state_code": "MH"
+  },
+  {
+    "id": 133267,
+    "name": "Nandgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147838,
+    "name": "Nandnee",
+    "state_code": "MH"
+  },
+  {
+    "id": 147839,
+    "name": "Nandura",
+    "state_code": "MH"
+  },
+  {
+    "id": 133268,
+    "name": "Nandura Buzurg",
+    "state_code": "MH"
+  },
+  {
+    "id": 133145,
+    "name": "Nandurbar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147840,
+    "name": "Narayangaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147841,
+    "name": "Nardana",
+    "state_code": "MH"
+  },
+  {
+    "id": 147842,
+    "name": "Nariman Point",
+    "state_code": "MH"
+  },
+  {
+    "id": 147843,
+    "name": "Narkhed",
+    "state_code": "MH"
+  },
+  {
+    "id": 133177,
+    "name": "Nashik",
+    "state_code": "MH"
+  },
+  {
+    "id": 133178,
+    "name": "Nashik Division",
+    "state_code": "MH"
+  },
+  {
+    "id": 147844,
+    "name": "Navapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 133186,
+    "name": "Navi Mumbai",
+    "state_code": "MH"
+  },
+  {
+    "id": 133208,
+    "name": "Neral",
+    "state_code": "MH"
+  },
+  {
+    "id": 147845,
+    "name": "Nerur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147846,
+    "name": "Nevasa",
+    "state_code": "MH"
+  },
+  {
+    "id": 147847,
+    "name": "Nighoj",
+    "state_code": "MH"
+  },
+  {
+    "id": 133217,
+    "name": "Nilanga",
+    "state_code": "MH"
+  },
+  {
+    "id": 133220,
+    "name": "Nipani",
+    "state_code": "MH"
+  },
+  {
+    "id": 147848,
+    "name": "Niphad",
+    "state_code": "MH"
+  },
+  {
+    "id": 147849,
+    "name": "Nira Narsingpur",
+    "state_code": "MH"
+  },
+  {
+    "id": 133305,
+    "name": "Osmanabad",
+    "state_code": "MH"
+  },
+  {
+    "id": 133307,
+    "name": "Ozar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147850,
+    "name": "Pabal",
+    "state_code": "MH"
+  },
+  {
+    "id": 133520,
+    "name": "Pachora",
+    "state_code": "MH"
+  },
+  {
+    "id": 147851,
+    "name": "Pahur Maharashtra",
+    "state_code": "MH"
+  },
+  {
+    "id": 133319,
+    "name": "Paithan",
+    "state_code": "MH"
+  },
+  {
+    "id": 133527,
+    "name": "Palghar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147852,
+    "name": "Pali Raigad",
+    "state_code": "MH"
+  },
+  {
+    "id": 147853,
+    "name": "Palso",
+    "state_code": "MH"
+  },
+  {
+    "id": 133537,
+    "name": "Panchgani",
+    "state_code": "MH"
+  },
+  {
+    "id": 133347,
+    "name": "Pandharpur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147854,
+    "name": "Pandhurli",
+    "state_code": "MH"
+  },
+  {
+    "id": 133349,
+    "name": "Panhala",
+    "state_code": "MH"
+  },
+  {
+    "id": 133353,
+    "name": "Panvel",
+    "state_code": "MH"
+  },
+  {
+    "id": 133358,
+    "name": "Parbhani",
+    "state_code": "MH"
+  },
+  {
+    "id": 147855,
+    "name": "Parel",
+    "state_code": "MH"
+  },
+  {
+    "id": 133360,
+    "name": "Parli Vaijnath",
+    "state_code": "MH"
+  },
+  {
+    "id": 147856,
+    "name": "Parner",
+    "state_code": "MH"
+  },
+  {
+    "id": 133364,
+    "name": "Parola",
+    "state_code": "MH"
+  },
+  {
+    "id": 147857,
+    "name": "Parseoni",
+    "state_code": "MH"
+  },
+  {
+    "id": 133367,
+    "name": "Partur",
+    "state_code": "MH"
+  },
+  {
+    "id": 133554,
+    "name": "Patan",
+    "state_code": "MH"
+  },
+  {
+    "id": 133556,
+    "name": "Pathardi",
+    "state_code": "MH"
+  },
+  {
+    "id": 133558,
+    "name": "Pathri",
+    "state_code": "MH"
+  },
+  {
+    "id": 133559,
+    "name": "Patur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147858,
+    "name": "Paturda",
+    "state_code": "MH"
+  },
+  {
+    "id": 147859,
+    "name": "Paud",
+    "state_code": "MH"
+  },
+  {
+    "id": 147860,
+    "name": "Pauni",
+    "state_code": "MH"
+  },
+  {
+    "id": 133397,
+    "name": "Pawni",
+    "state_code": "MH"
+  },
+  {
+    "id": 147861,
+    "name": "Pedgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147862,
+    "name": "Peint",
+    "state_code": "MH"
+  },
+  {
+    "id": 133404,
+    "name": "Pen",
+    "state_code": "MH"
+  },
+  {
+    "id": 133434,
+    "name": "Phaltan",
+    "state_code": "MH"
+  },
+  {
+    "id": 147863,
+    "name": "Phulambri",
+    "state_code": "MH"
+  },
+  {
+    "id": 147864,
+    "name": "Piliv",
+    "state_code": "MH"
+  },
+  {
+    "id": 147865,
+    "name": "Pimpalgaon Baswant",
+    "state_code": "MH"
+  },
+  {
+    "id": 147866,
+    "name": "Pimpalgaon Raja",
+    "state_code": "MH"
+  },
+  {
+    "id": 133449,
+    "name": "Pimpri",
+    "state_code": "MH"
+  },
+  {
+    "id": 147867,
+    "name": "Pimpri-Chinchwad",
+    "state_code": "MH"
+  },
+  {
+    "id": 133564,
+    "name": "Pipri",
+    "state_code": "MH"
+  },
+  {
+    "id": 133484,
+    "name": "Powai",
+    "state_code": "MH"
+  },
+  {
+    "id": 147868,
+    "name": "Prabhadevi",
+    "state_code": "MH"
+  },
+  {
+    "id": 147869,
+    "name": "Prakasha",
+    "state_code": "MH"
+  },
+  {
+    "id": 133496,
+    "name": "Pulgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 133504,
+    "name": "Pune",
+    "state_code": "MH"
+  },
+  {
+    "id": 133505,
+    "name": "Pune Division",
+    "state_code": "MH"
+  },
+  {
+    "id": 147870,
+    "name": "Puntamba",
+    "state_code": "MH"
+  },
+  {
+    "id": 147871,
+    "name": "Pural",
+    "state_code": "MH"
+  },
+  {
+    "id": 133571,
+    "name": "Purna",
+    "state_code": "MH"
+  },
+  {
+    "id": 133515,
+    "name": "Pusad",
+    "state_code": "MH"
+  },
+  {
+    "id": 147872,
+    "name": "Radhanagari",
+    "state_code": "MH"
+  },
+  {
+    "id": 147873,
+    "name": "Rahata",
+    "state_code": "MH"
+  },
+  {
+    "id": 133583,
+    "name": "Rahimatpur",
+    "state_code": "MH"
+  },
+  {
+    "id": 133663,
+    "name": "Rahuri",
+    "state_code": "MH"
+  },
+  {
+    "id": 133588,
+    "name": "Raigarh",
+    "state_code": "MH"
+  },
+  {
+    "id": 147874,
+    "name": "Raireshwar",
+    "state_code": "MH"
+  },
+  {
+    "id": 133687,
+    "name": "Rajapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 133677,
+    "name": "Rajgurunagar",
+    "state_code": "MH"
+  },
+  {
+    "id": 133685,
+    "name": "Rajur",
+    "state_code": "MH"
+  },
+  {
+    "id": 133689,
+    "name": "Rajura",
+    "state_code": "MH"
+  },
+  {
+    "id": 147875,
+    "name": "Ralegaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147876,
+    "name": "Ramewadi",
+    "state_code": "MH"
+  },
+  {
+    "id": 133710,
+    "name": "Ramtek",
+    "state_code": "MH"
+  },
+  {
+    "id": 133619,
+    "name": "Ratnagiri",
+    "state_code": "MH"
+  },
+  {
+    "id": 133724,
+    "name": "Raver",
+    "state_code": "MH"
+  },
+  {
+    "id": 147877,
+    "name": "Renapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147878,
+    "name": "Renavi",
+    "state_code": "MH"
+  },
+  {
+    "id": 133631,
+    "name": "Revadanda",
+    "state_code": "MH"
+  },
+  {
+    "id": 147879,
+    "name": "Revdanda",
+    "state_code": "MH"
+  },
+  {
+    "id": 133639,
+    "name": "Risod",
+    "state_code": "MH"
+  },
+  {
+    "id": 133644,
+    "name": "Roha",
+    "state_code": "MH"
+  },
+  {
+    "id": 147880,
+    "name": "Sailu",
+    "state_code": "MH"
+  },
+  {
+    "id": 147881,
+    "name": "Sakol",
+    "state_code": "MH"
+  },
+  {
+    "id": 147882,
+    "name": "Sakoli",
+    "state_code": "MH"
+  },
+  {
+    "id": 147883,
+    "name": "Sakri",
+    "state_code": "MH"
+  },
+  {
+    "id": 147884,
+    "name": "Samudrapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147885,
+    "name": "Sangameshwar",
+    "state_code": "MH"
+  },
+  {
+    "id": 133780,
+    "name": "Sangamner",
+    "state_code": "MH"
+  },
+  {
+    "id": 133782,
+    "name": "Sangli",
+    "state_code": "MH"
+  },
+  {
+    "id": 134074,
+    "name": "Sangola",
+    "state_code": "MH"
+  },
+  {
+    "id": 147887,
+    "name": "Sangrampur Maharashtra",
+    "state_code": "MH"
+  },
+  {
+    "id": 147888,
+    "name": "Saoli",
+    "state_code": "MH"
+  },
+  {
+    "id": 133797,
+    "name": "Saoner",
+    "state_code": "MH"
+  },
+  {
+    "id": 147889,
+    "name": "Sarangkheda",
+    "state_code": "MH"
+  },
+  {
+    "id": 147890,
+    "name": "Saswad",
+    "state_code": "MH"
+  },
+  {
+    "id": 133825,
+    "name": "Satana",
+    "state_code": "MH"
+  },
+  {
+    "id": 133815,
+    "name": "Satara",
+    "state_code": "MH"
+  },
+  {
+    "id": 133816,
+    "name": "Satara Division",
+    "state_code": "MH"
+  },
+  {
+    "id": 147891,
+    "name": "Satpati",
+    "state_code": "MH"
+  },
+  {
+    "id": 134082,
+    "name": "Savantvadi",
+    "state_code": "MH"
+  },
+  {
+    "id": 134083,
+    "name": "Savda",
+    "state_code": "MH"
+  },
+  {
+    "id": 147892,
+    "name": "Savlaj",
+    "state_code": "MH"
+  },
+  {
+    "id": 147893,
+    "name": "Sawantvadi",
+    "state_code": "MH"
+  },
+  {
+    "id": 133836,
+    "name": "Selu",
+    "state_code": "MH"
+  },
+  {
+    "id": 147894,
+    "name": "Sevagram",
+    "state_code": "MH"
+  },
+  {
+    "id": 147895,
+    "name": "Sewri",
+    "state_code": "MH"
+  },
+  {
+    "id": 133908,
+    "name": "Shahada",
+    "state_code": "MH"
+  },
+  {
+    "id": 133909,
+    "name": "Shahapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147896,
+    "name": "Shedbal",
+    "state_code": "MH"
+  },
+  {
+    "id": 133857,
+    "name": "Shegaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147897,
+    "name": "Shevgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147898,
+    "name": "Shikrapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 133873,
+    "name": "Shiraguppi",
+    "state_code": "MH"
+  },
+  {
+    "id": 147899,
+    "name": "Shirala",
+    "state_code": "MH"
+  },
+  {
+    "id": 133874,
+    "name": "Shirdi",
+    "state_code": "MH"
+  },
+  {
+    "id": 133875,
+    "name": "Shirgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147900,
+    "name": "Shirol",
+    "state_code": "MH"
+  },
+  {
+    "id": 133877,
+    "name": "Shirpur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147901,
+    "name": "Shirud",
+    "state_code": "MH"
+  },
+  {
+    "id": 133878,
+    "name": "Shirwal",
+    "state_code": "MH"
+  },
+  {
+    "id": 133879,
+    "name": "Shivaji Nagar",
+    "state_code": "MH"
+  },
+  {
+    "id": 133886,
+    "name": "Shrigonda",
+    "state_code": "MH"
+  },
+  {
+    "id": 133936,
+    "name": "Sillod",
+    "state_code": "MH"
+  },
+  {
+    "id": 147902,
+    "name": "Sindewahi",
+    "state_code": "MH"
+  },
+  {
+    "id": 133943,
+    "name": "Sindhudurg",
+    "state_code": "MH"
+  },
+  {
+    "id": 133944,
+    "name": "Sindi",
+    "state_code": "MH"
+  },
+  {
+    "id": 147903,
+    "name": "Sindkheda",
+    "state_code": "MH"
+  },
+  {
+    "id": 133953,
+    "name": "Sinnar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147904,
+    "name": "Sion Mumbai",
+    "state_code": "MH"
+  },
+  {
+    "id": 147905,
+    "name": "Sironcha",
+    "state_code": "MH"
+  },
+  {
+    "id": 133970,
+    "name": "Sirur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147906,
+    "name": "Sivala East Godavari district",
+    "state_code": "MH"
+  },
+  {
+    "id": 133986,
+    "name": "Solapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147907,
+    "name": "Sonala",
+    "state_code": "MH"
+  },
+  {
+    "id": 133993,
+    "name": "Sonegaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147908,
+    "name": "Songir",
+    "state_code": "MH"
+  },
+  {
+    "id": 147909,
+    "name": "Sonvad",
+    "state_code": "MH"
+  },
+  {
+    "id": 134015,
+    "name": "Soygaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 134033,
+    "name": "Srivardhan",
+    "state_code": "MH"
+  },
+  {
+    "id": 134052,
+    "name": "Surgana",
+    "state_code": "MH"
+  },
+  {
+    "id": 147910,
+    "name": "Taklibhan",
+    "state_code": "MH"
+  },
+  {
+    "id": 147911,
+    "name": "Talbid",
+    "state_code": "MH"
+  },
+  {
+    "id": 134100,
+    "name": "Talegaon Dabhade",
+    "state_code": "MH"
+  },
+  {
+    "id": 147912,
+    "name": "Talegaon Dhamdhere",
+    "state_code": "MH"
+  },
+  {
+    "id": 134104,
+    "name": "Taloda",
+    "state_code": "MH"
+  },
+  {
+    "id": 147913,
+    "name": "Talode",
+    "state_code": "MH"
+  },
+  {
+    "id": 134241,
+    "name": "Tarapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147914,
+    "name": "Tardeo",
+    "state_code": "MH"
+  },
+  {
+    "id": 134242,
+    "name": "Tasgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 134128,
+    "name": "Telhara",
+    "state_code": "MH"
+  },
+  {
+    "id": 147915,
+    "name": "Thalner",
+    "state_code": "MH"
+  },
+  {
+    "id": 134138,
+    "name": "Thane",
+    "state_code": "MH"
+  },
+  {
+    "id": 134212,
+    "name": "Trimbak",
+    "state_code": "MH"
+  },
+  {
+    "id": 147916,
+    "name": "Trombay",
+    "state_code": "MH"
+  },
+  {
+    "id": 134217,
+    "name": "Tuljapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 134221,
+    "name": "Tumsar",
+    "state_code": "MH"
+  },
+  {
+    "id": 134255,
+    "name": "Udgir",
+    "state_code": "MH"
+  },
+  {
+    "id": 134267,
+    "name": "Ulhasnagar",
+    "state_code": "MH"
+  },
+  {
+    "id": 134269,
+    "name": "Umarga",
+    "state_code": "MH"
+  },
+  {
+    "id": 134272,
+    "name": "Umarkhed",
+    "state_code": "MH"
+  },
+  {
+    "id": 134274,
+    "name": "Umred",
+    "state_code": "MH"
+  },
+  {
+    "id": 134291,
+    "name": "Uran",
+    "state_code": "MH"
+  },
+  {
+    "id": 147917,
+    "name": "Uruli Kanchan",
+    "state_code": "MH"
+  },
+  {
+    "id": 134379,
+    "name": "Vada",
+    "state_code": "MH"
+  },
+  {
+    "id": 147918,
+    "name": "Vadgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147919,
+    "name": "Vadner",
+    "state_code": "MH"
+  },
+  {
+    "id": 134312,
+    "name": "Vaijapur",
+    "state_code": "MH"
+  },
+  {
+    "id": 147920,
+    "name": "Vairag",
+    "state_code": "MH"
+  },
+  {
+    "id": 147921,
+    "name": "Valsang",
+    "state_code": "MH"
+  },
+  {
+    "id": 147922,
+    "name": "Vangaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 134328,
+    "name": "Varangaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147923,
+    "name": "Vashi",
+    "state_code": "MH"
+  },
+  {
+    "id": 134334,
+    "name": "Vasind",
+    "state_code": "MH"
+  },
+  {
+    "id": 147924,
+    "name": "Vatul",
+    "state_code": "MH"
+  },
+  {
+    "id": 147925,
+    "name": "Velas Maharashtra",
+    "state_code": "MH"
+  },
+  {
+    "id": 147926,
+    "name": "Velneshwar",
+    "state_code": "MH"
+  },
+  {
+    "id": 134346,
+    "name": "Vengurla",
+    "state_code": "MH"
+  },
+  {
+    "id": 147927,
+    "name": "Vijaydurg",
+    "state_code": "MH"
+  },
+  {
+    "id": 147928,
+    "name": "Vikhroli",
+    "state_code": "MH"
+  },
+  {
+    "id": 147929,
+    "name": "Vile Parle",
+    "state_code": "MH"
+  },
+  {
+    "id": 147930,
+    "name": "Vinchur",
+    "state_code": "MH"
+  },
+  {
+    "id": 134368,
+    "name": "Virar",
+    "state_code": "MH"
+  },
+  {
+    "id": 147931,
+    "name": "Vita Maharashtra",
+    "state_code": "MH"
+  },
+  {
+    "id": 134372,
+    "name": "Vite",
+    "state_code": "MH"
+  },
+  {
+    "id": 147932,
+    "name": "Wadala",
+    "state_code": "MH"
+  },
+  {
+    "id": 134388,
+    "name": "Wadgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147933,
+    "name": "Wadner",
+    "state_code": "MH"
+  },
+  {
+    "id": 147934,
+    "name": "Wadwani",
+    "state_code": "MH"
+  },
+  {
+    "id": 147935,
+    "name": "Wagholi",
+    "state_code": "MH"
+  },
+  {
+    "id": 134390,
+    "name": "Wai",
+    "state_code": "MH"
+  },
+  {
+    "id": 147936,
+    "name": "Wakad",
+    "state_code": "MH"
+  },
+  {
+    "id": 147937,
+    "name": "Walgaon",
+    "state_code": "MH"
+  },
+  {
+    "id": 147938,
+    "name": "Walki",
+    "state_code": "MH"
+  },
+  {
+    "id": 134393,
+    "name": "Wani",
+    "state_code": "MH"
+  },
+  {
+    "id": 134396,
+    "name": "Wardha",
+    "state_code": "MH"
+  },
+  {
+    "id": 134397,
+    "name": "Warora",
+    "state_code": "MH"
+  },
+  {
+    "id": 134398,
+    "name": "Warud",
+    "state_code": "MH"
+  },
+  {
+    "id": 134399,
+    "name": "Washim",
+    "state_code": "MH"
+  },
+  {
+    "id": 147939,
+    "name": "Worli",
+    "state_code": "MH"
+  },
+  {
+    "id": 134438,
+    "name": "Yaval",
+    "state_code": "MH"
+  },
+  {
+    "id": 134427,
+    "name": "Yavatmal",
+    "state_code": "MH"
+  },
+  {
+    "id": 134434,
+    "name": "Yeola",
+    "state_code": "MH"
+  },
+  {
+    "id": 58064,
+    "name": "Bishnupur",
+    "state_code": "MN"
+  },
+  {
+    "id": 153522,
+    "name": "Chandel",
+    "state_code": "MN"
+  },
+  {
+    "id": 131585,
+    "name": "Churachandpur",
+    "state_code": "MN"
+  },
+  {
+    "id": 132162,
+    "name": "Imphal East",
+    "state_code": "MN"
+  },
+  {
+    "id": 132953,
+    "name": "Imphal West",
+    "state_code": "MN"
+  },
+  {
+    "id": 153527,
+    "name": "Jiribam",
+    "state_code": "MN"
+  },
+  {
+    "id": 132341,
+    "name": "Kakching",
+    "state_code": "MN"
+  },
+  {
+    "id": 153526,
+    "name": "Kamjong",
+    "state_code": "MN"
+  },
+  {
+    "id": 153523,
+    "name": "Kangpokpi",
+    "state_code": "MN"
+  },
+  {
+    "id": 153528,
+    "name": "Noney",
+    "state_code": "MN"
+  },
+  {
+    "id": 153525,
+    "name": "Pherzawl",
+    "state_code": "MN"
+  },
+  {
+    "id": 133837,
+    "name": "Senapati",
+    "state_code": "MN"
+  },
+  {
+    "id": 134109,
+    "name": "Tamenglong",
+    "state_code": "MN"
+  },
+  {
+    "id": 153524,
+    "name": "Tengnoupal",
+    "state_code": "MN"
+  },
+  {
+    "id": 134159,
+    "name": "Thoubal",
+    "state_code": "MN"
+  },
+  {
+    "id": 134264,
+    "name": "Ukhrul",
+    "state_code": "MN"
+  },
+  {
+    "id": 131520,
+    "name": "Cherrapunji",
+    "state_code": "ML"
+  },
+  {
+    "id": 131824,
+    "name": "East Garo Hills",
+    "state_code": "ML"
+  },
+  {
+    "id": 131825,
+    "name": "East Jaintia Hills",
+    "state_code": "ML"
+  },
+  {
+    "id": 131827,
+    "name": "East Khasi Hills",
+    "state_code": "ML"
+  },
+  {
+    "id": 132858,
+    "name": "Mairang",
+    "state_code": "ML"
+  },
+  {
+    "id": 132916,
+    "name": "Mankachar",
+    "state_code": "ML"
+  },
+  {
+    "id": 133232,
+    "name": "Nongpoh",
+    "state_code": "ML"
+  },
+  {
+    "id": 133233,
+    "name": "Nongstoin",
+    "state_code": "ML"
+  },
+  {
+    "id": 133237,
+    "name": "North Garo Hills",
+    "state_code": "ML"
+  },
+  {
+    "id": 133636,
+    "name": "Ri-Bhoi",
+    "state_code": "ML"
+  },
+  {
+    "id": 133870,
+    "name": "Shillong",
+    "state_code": "ML"
+  },
+  {
+    "id": 134009,
+    "name": "South Garo Hills",
+    "state_code": "ML"
+  },
+  {
+    "id": 134013,
+    "name": "South West Garo Hills",
+    "state_code": "ML"
+  },
+  {
+    "id": 134014,
+    "name": "South West Khasi Hills",
+    "state_code": "ML"
+  },
+  {
+    "id": 134223,
+    "name": "Tura",
+    "state_code": "ML"
+  },
+  {
+    "id": 134406,
+    "name": "West Garo Hills",
+    "state_code": "ML"
+  },
+  {
+    "id": 134408,
+    "name": "West Jaintia Hills",
+    "state_code": "ML"
+  },
+  {
+    "id": 134410,
+    "name": "West Khasi Hills",
+    "state_code": "ML"
+  },
+  {
+    "id": 57610,
+    "name": "Aizawl",
+    "state_code": "MZ"
+  },
+  {
+    "id": 58184,
+    "name": "Champhai",
+    "state_code": "MZ"
+  },
+  {
+    "id": 131656,
+    "name": "Darlawn",
+    "state_code": "MZ"
+  },
+  {
+    "id": 132486,
+    "name": "Khawhai",
+    "state_code": "MZ"
+  },
+  {
+    "id": 132554,
+    "name": "Kolasib",
+    "state_code": "MZ"
+  },
+  {
+    "id": 132761,
+    "name": "Lawngtlai",
+    "state_code": "MZ"
+  },
+  {
+    "id": 132787,
+    "name": "Lunglei",
+    "state_code": "MZ"
+  },
+  {
+    "id": 132879,
+    "name": "Mamit",
+    "state_code": "MZ"
+  },
+  {
+    "id": 133242,
+    "name": "North Vanlaiphai",
+    "state_code": "MZ"
+  },
+  {
+    "id": 133756,
+    "name": "Saiha",
+    "state_code": "MZ"
+  },
+  {
+    "id": 133759,
+    "name": "Sairang",
+    "state_code": "MZ"
+  },
+  {
+    "id": 134063,
+    "name": "Saitlaw",
+    "state_code": "MZ"
+  },
+  {
+    "id": 133847,
+    "name": "Serchhip",
+    "state_code": "MZ"
+  },
+  {
+    "id": 134148,
+    "name": "Thenzawl",
+    "state_code": "MZ"
+  },
+  {
+    "id": 131771,
+    "name": "Dimapur",
+    "state_code": "NL"
+  },
+  {
+    "id": 132549,
+    "name": "Kohima",
+    "state_code": "NL"
+  },
+  {
+    "id": 132989,
+    "name": "Mokokchung",
+    "state_code": "NL"
+  },
+  {
+    "id": 132990,
+    "name": "Mon",
+    "state_code": "NL"
+  },
+  {
+    "id": 133416,
+    "name": "Peren",
+    "state_code": "NL"
+  },
+  {
+    "id": 133438,
+    "name": "Phek",
+    "state_code": "NL"
+  },
+  {
+    "id": 134215,
+    "name": "Tuensang",
+    "state_code": "NL"
+  },
+  {
+    "id": 134216,
+    "name": "Tuensang District",
+    "state_code": "NL"
+  },
+  {
+    "id": 134413,
+    "name": "Wokha",
+    "state_code": "NL"
+  },
+  {
+    "id": 134445,
+    "name": "Zunheboto",
+    "state_code": "NL"
+  },
+  {
+    "id": 57704,
+    "name": "Angul",
+    "state_code": "OR"
+  },
+  {
+    "id": 57705,
+    "name": "Angul District",
+    "state_code": "OR"
+  },
+  {
+    "id": 134465,
+    "name": "Asika",
+    "state_code": "OR"
+  },
+  {
+    "id": 134467,
+    "name": "Athagarh",
+    "state_code": "OR"
+  },
+  {
+    "id": 57785,
+    "name": "Bada Barabil",
+    "state_code": "OR"
+  },
+  {
+    "id": 57835,
+    "name": "Balangir",
+    "state_code": "OR"
+  },
+  {
+    "id": 57823,
+    "name": "Balasore",
+    "state_code": "OR"
+  },
+  {
+    "id": 58114,
+    "name": "Baleshwar",
+    "state_code": "OR"
+  },
+  {
+    "id": 57826,
+    "name": "Balimila",
+    "state_code": "OR"
+  },
+  {
+    "id": 58117,
+    "name": "Balugaon",
+    "state_code": "OR"
+  },
+  {
+    "id": 58123,
+    "name": "Banapur",
+    "state_code": "OR"
+  },
+  {
+    "id": 58128,
+    "name": "Banki",
+    "state_code": "OR"
+  },
+  {
+    "id": 58129,
+    "name": "Banposh",
+    "state_code": "OR"
+  },
+  {
+    "id": 57862,
+    "name": "Baragarh",
+    "state_code": "OR"
+  },
+  {
+    "id": 57866,
+    "name": "Barbil",
+    "state_code": "OR"
+  },
+  {
+    "id": 57869,
+    "name": "Bargarh",
+    "state_code": "OR"
+  },
+  {
+    "id": 57886,
+    "name": "Barpali",
+    "state_code": "OR"
+  },
+  {
+    "id": 58149,
+    "name": "Basudebpur",
+    "state_code": "OR"
+  },
+  {
+    "id": 57907,
+    "name": "Baud",
+    "state_code": "OR"
+  },
+  {
+    "id": 57908,
+    "name": "Baudh",
+    "state_code": "OR"
+  },
+  {
+    "id": 57921,
+    "name": "Belaguntha",
+    "state_code": "OR"
+  },
+  {
+    "id": 57953,
+    "name": "Bhadrak",
+    "state_code": "OR"
+  },
+  {
+    "id": 57954,
+    "name": "Bhadrakh",
+    "state_code": "OR"
+  },
+  {
+    "id": 57963,
+    "name": "Bhanjanagar",
+    "state_code": "OR"
+  },
+  {
+    "id": 57976,
+    "name": "Bhawanipatna",
+    "state_code": "OR"
+  },
+  {
+    "id": 57999,
+    "name": "Bhuban",
+    "state_code": "OR"
+  },
+  {
+    "id": 58000,
+    "name": "Bhubaneswar",
+    "state_code": "OR"
+  },
+  {
+    "id": 58058,
+    "name": "Binka",
+    "state_code": "OR"
+  },
+  {
+    "id": 58060,
+    "name": "Birmitrapur",
+    "state_code": "OR"
+  },
+  {
+    "id": 58079,
+    "name": "Bolanikhodan",
+    "state_code": "OR"
+  },
+  {
+    "id": 58086,
+    "name": "Brahmapur",
+    "state_code": "OR"
+  },
+  {
+    "id": 58087,
+    "name": "Brajarajnagar",
+    "state_code": "OR"
+  },
+  {
+    "id": 58092,
+    "name": "Buguda",
+    "state_code": "OR"
+  },
+  {
+    "id": 58099,
+    "name": "Burla",
+    "state_code": "OR"
+  },
+  {
+    "id": 131594,
+    "name": "Champua",
+    "state_code": "OR"
+  },
+  {
+    "id": 131597,
+    "name": "Chandbali",
+    "state_code": "OR"
+  },
+  {
+    "id": 131510,
+    "name": "Chatrapur",
+    "state_code": "OR"
+  },
+  {
+    "id": 131550,
+    "name": "Chikitigarh",
+    "state_code": "OR"
+  },
+  {
+    "id": 131573,
+    "name": "Chittarkonda",
+    "state_code": "OR"
+  },
+  {
+    "id": 131633,
+    "name": "Cuttack",
+    "state_code": "OR"
+  },
+  {
+    "id": 131643,
+    "name": "Daitari",
+    "state_code": "OR"
+  },
+  {
+    "id": 131683,
+    "name": "Deogarh",
+    "state_code": "OR"
+  },
+  {
+    "id": 131735,
+    "name": "Dhenkanal",
+    "state_code": "OR"
+  },
+  {
+    "id": 131765,
+    "name": "Digapahandi",
+    "state_code": "OR"
+  },
+  {
+    "id": 131892,
+    "name": "Gajapati",
+    "state_code": "OR"
+  },
+  {
+    "id": 131914,
+    "name": "Ganjam",
+    "state_code": "OR"
+  },
+  {
+    "id": 131988,
+    "name": "Gopalpur",
+    "state_code": "OR"
+  },
+  {
+    "id": 132013,
+    "name": "Gudari",
+    "state_code": "OR"
+  },
+  {
+    "id": 132030,
+    "name": "Gunupur",
+    "state_code": "OR"
+  },
+  {
+    "id": 132102,
+    "name": "Hinjilikatu",
+    "state_code": "OR"
+  },
+  {
+    "id": 132148,
+    "name": "Hirakud",
+    "state_code": "OR"
+  },
+  {
+    "id": 132185,
+    "name": "Jagatsinghpur",
+    "state_code": "OR"
+  },
+  {
+    "id": 132209,
+    "name": "Jajpur",
+    "state_code": "OR"
+  },
+  {
+    "id": 132213,
+    "name": "Jaleshwar",
+    "state_code": "OR"
+  },
+  {
+    "id": 132250,
+    "name": "Jatani",
+    "state_code": "OR"
+  },
+  {
+    "id": 132265,
+    "name": "Jeypore",
+    "state_code": "OR"
+  },
+  {
+    "id": 132269,
+    "name": "Jharsuguda",
+    "state_code": "OR"
+  },
+  {
+    "id": 132270,
+    "name": "Jharsuguda District",
+    "state_code": "OR"
+  },
+  {
+    "id": 132338,
+    "name": "Kaintragarh",
+    "state_code": "OR"
+  },
+  {
+    "id": 132687,
+    "name": "Kalahandi",
+    "state_code": "OR"
+  },
+  {
+    "id": 132695,
+    "name": "Kamakhyanagar",
+    "state_code": "OR"
+  },
+  {
+    "id": 132371,
+    "name": "Kandhamal",
+    "state_code": "OR"
+  },
+  {
+    "id": 132387,
+    "name": "Kantabanji",
+    "state_code": "OR"
+  },
+  {
+    "id": 132386,
+    "name": "Kantilo",
+    "state_code": "OR"
+  },
+  {
+    "id": 132441,
+    "name": "Kendrapara",
+    "state_code": "OR"
+  },
+  {
+    "id": 132444,
+    "name": "Kendujhar",
+    "state_code": "OR"
+  },
+  {
+    "id": 132448,
+    "name": "Kesinga",
+    "state_code": "OR"
+  },
+  {
+    "id": 132458,
+    "name": "Khallikot",
+    "state_code": "OR"
+  },
+  {
+    "id": 132477,
+    "name": "Kharhial",
+    "state_code": "OR"
+  },
+  {
+    "id": 132501,
+    "name": "Khordha",
+    "state_code": "OR"
+  },
+  {
+    "id": 132508,
+    "name": "Khurda",
+    "state_code": "OR"
+  },
+  {
+    "id": 132527,
+    "name": "Kiri Buru",
+    "state_code": "OR"
+  },
+  {
+    "id": 132539,
+    "name": "Kodala",
+    "state_code": "OR"
+  },
+  {
+    "id": 132570,
+    "name": "Konarka",
+    "state_code": "OR"
+  },
+  {
+    "id": 132578,
+    "name": "Koraput",
+    "state_code": "OR"
+  },
+  {
+    "id": 132624,
+    "name": "Kuchaiburi",
+    "state_code": "OR"
+  },
+  {
+    "id": 132626,
+    "name": "Kuchinda",
+    "state_code": "OR"
+  },
+  {
+    "id": 132871,
+    "name": "Malkangiri",
+    "state_code": "OR"
+  },
+  {
+    "id": 132954,
+    "name": "Mayurbhanj",
+    "state_code": "OR"
+  },
+  {
+    "id": 133104,
+    "name": "Nabarangpur",
+    "state_code": "OR"
+  },
+  {
+    "id": 133196,
+    "name": "Nayagarh",
+    "state_code": "OR"
+  },
+  {
+    "id": 133195,
+    "name": "Nayagarh District",
+    "state_code": "OR"
+  },
+  {
+    "id": 133285,
+    "name": "Nilgiri",
+    "state_code": "OR"
+  },
+  {
+    "id": 133219,
+    "name": "Nimaparha",
+    "state_code": "OR"
+  },
+  {
+    "id": 133245,
+    "name": "Nowrangapur",
+    "state_code": "OR"
+  },
+  {
+    "id": 133247,
+    "name": "Nuapada",
+    "state_code": "OR"
+  },
+  {
+    "id": 133312,
+    "name": "Padampur",
+    "state_code": "OR"
+  },
+  {
+    "id": 133370,
+    "name": "Paradip Garh",
+    "state_code": "OR"
+  },
+  {
+    "id": 133393,
+    "name": "Patamundai",
+    "state_code": "OR"
+  },
+  {
+    "id": 133387,
+    "name": "Patnagarh",
+    "state_code": "OR"
+  },
+  {
+    "id": 133441,
+    "name": "Phulbani",
+    "state_code": "OR"
+  },
+  {
+    "id": 133453,
+    "name": "Pipili",
+    "state_code": "OR"
+  },
+  {
+    "id": 133467,
+    "name": "Polasara",
+    "state_code": "OR"
+  },
+  {
+    "id": 133511,
+    "name": "Puri",
+    "state_code": "OR"
+  },
+  {
+    "id": 133513,
+    "name": "Purushottampur",
+    "state_code": "OR"
+  },
+  {
+    "id": 133602,
+    "name": "Rambha",
+    "state_code": "OR"
+  },
+  {
+    "id": 133620,
+    "name": "Raurkela",
+    "state_code": "OR"
+  },
+  {
+    "id": 133622,
+    "name": "Rayagada",
+    "state_code": "OR"
+  },
+  {
+    "id": 133625,
+    "name": "Remuna",
+    "state_code": "OR"
+  },
+  {
+    "id": 133626,
+    "name": "Rengali",
+    "state_code": "OR"
+  },
+  {
+    "id": 133769,
+    "name": "Sambalpur",
+    "state_code": "OR"
+  },
+  {
+    "id": 133994,
+    "name": "Sonepur",
+    "state_code": "OR"
+  },
+  {
+    "id": 134002,
+    "name": "Sorada",
+    "state_code": "OR"
+  },
+  {
+    "id": 134004,
+    "name": "Soro",
+    "state_code": "OR"
+  },
+  {
+    "id": 134034,
+    "name": "Subarnapur",
+    "state_code": "OR"
+  },
+  {
+    "id": 134044,
+    "name": "Sundargarh",
+    "state_code": "OR"
+  },
+  {
+    "id": 134232,
+    "name": "Talcher",
+    "state_code": "OR"
+  },
+  {
+    "id": 134115,
+    "name": "Tarabha",
+    "state_code": "OR"
+  },
+  {
+    "id": 134201,
+    "name": "Titlagarh",
+    "state_code": "OR"
+  },
+  {
+    "id": 134254,
+    "name": "Udayagiri",
+    "state_code": "OR"
+  },
+  {
+    "id": 132715,
+    "name": "Karaikal",
+    "state_code": "PY"
+  },
+  {
+    "id": 132830,
+    "name": "Mahe",
+    "state_code": "PY"
+  },
+  {
+    "id": 133490,
+    "name": "Puducherry",
+    "state_code": "PY"
+  },
+  {
+    "id": 134425,
+    "name": "Yanam",
+    "state_code": "PY"
+  },
+  {
+    "id": 57587,
+    "name": "Abohar",
+    "state_code": "PB"
+  },
+  {
+    "id": 57592,
+    "name": "Adampur",
+    "state_code": "PB"
+  },
+  {
+    "id": 57612,
+    "name": "Ajitgarh",
+    "state_code": "PB"
+  },
+  {
+    "id": 57615,
+    "name": "Ajnala",
+    "state_code": "PB"
+  },
+  {
+    "id": 57629,
+    "name": "Akalgarh",
+    "state_code": "PB"
+  },
+  {
+    "id": 57651,
+    "name": "Alawalpur",
+    "state_code": "PB"
+  },
+  {
+    "id": 57681,
+    "name": "Amloh",
+    "state_code": "PB"
+  },
+  {
+    "id": 57686,
+    "name": "Amritsar",
+    "state_code": "PB"
+  },
+  {
+    "id": 57697,
+    "name": "Anandpur Sahib",
+    "state_code": "PB"
+  },
+  {
+    "id": 57791,
+    "name": "Badhni Kalan",
+    "state_code": "PB"
+  },
+  {
+    "id": 58109,
+    "name": "Bagha Purana",
+    "state_code": "PB"
+  },
+  {
+    "id": 57819,
+    "name": "Bakloh",
+    "state_code": "PB"
+  },
+  {
+    "id": 58118,
+    "name": "Balachor",
+    "state_code": "PB"
+  },
+  {
+    "id": 57846,
+    "name": "Banga",
+    "state_code": "PB"
+  },
+  {
+    "id": 57859,
+    "name": "Banur",
+    "state_code": "PB"
+  },
+  {
+    "id": 57882,
+    "name": "Barnala",
+    "state_code": "PB"
+  },
+  {
+    "id": 57906,
+    "name": "Batala",
+    "state_code": "PB"
+  },
+  {
+    "id": 57914,
+    "name": "Begowal",
+    "state_code": "PB"
+  },
+  {
+    "id": 57950,
+    "name": "Bhadaur",
+    "state_code": "PB"
+  },
+  {
+    "id": 57904,
+    "name": "Bhatinda",
+    "state_code": "PB"
+  },
+  {
+    "id": 57977,
+    "name": "Bhawanigarh",
+    "state_code": "PB"
+  },
+  {
+    "id": 58018,
+    "name": "Bhikhi",
+    "state_code": "PB"
+  },
+  {
+    "id": 57990,
+    "name": "Bhogpur",
+    "state_code": "PB"
+  },
+  {
+    "id": 143761,
+    "name": "Bholath",
+    "state_code": "PB"
+  },
+  {
+    "id": 58090,
+    "name": "Budhlada",
+    "state_code": "PB"
+  },
+  {
+    "id": 131610,
+    "name": "Chima",
+    "state_code": "PB"
+  },
+  {
+    "id": 131661,
+    "name": "Dasuya",
+    "state_code": "PB"
+  },
+  {
+    "id": 131696,
+    "name": "Dera Baba Nanak",
+    "state_code": "PB"
+  },
+  {
+    "id": 143763,
+    "name": "Dera Bassi",
+    "state_code": "PB"
+  },
+  {
+    "id": 131713,
+    "name": "Dhanaula",
+    "state_code": "PB"
+  },
+  {
+    "id": 131756,
+    "name": "Dhariwal",
+    "state_code": "PB"
+  },
+  {
+    "id": 131736,
+    "name": "Dhilwan",
+    "state_code": "PB"
+  },
+  {
+    "id": 143762,
+    "name": "Dhudi",
+    "state_code": "PB"
+  },
+  {
+    "id": 131760,
+    "name": "Dhuri",
+    "state_code": "PB"
+  },
+  {
+    "id": 131816,
+    "name": "Dina Nagar",
+    "state_code": "PB"
+  },
+  {
+    "id": 131777,
+    "name": "Dirba",
+    "state_code": "PB"
+  },
+  {
+    "id": 131790,
+    "name": "Doraha",
+    "state_code": "PB"
+  },
+  {
+    "id": 131859,
+    "name": "Faridkot",
+    "state_code": "PB"
+  },
+  {
+    "id": 131865,
+    "name": "Fatehgarh Churian",
+    "state_code": "PB"
+  },
+  {
+    "id": 131866,
+    "name": "Fatehgarh Sahib",
+    "state_code": "PB"
+  },
+  {
+    "id": 131881,
+    "name": "Fazilka",
+    "state_code": "PB"
+  },
+  {
+    "id": 131875,
+    "name": "Firozpur",
+    "state_code": "PB"
+  },
+  {
+    "id": 131877,
+    "name": "Firozpur District",
+    "state_code": "PB"
+  },
+  {
+    "id": 131918,
+    "name": "Gardhiwala",
+    "state_code": "PB"
+  },
+  {
+    "id": 131921,
+    "name": "Garhshankar",
+    "state_code": "PB"
+  },
+  {
+    "id": 131935,
+    "name": "Ghanaur",
+    "state_code": "PB"
+  },
+  {
+    "id": 131956,
+    "name": "Giddarbaha",
+    "state_code": "PB"
+  },
+  {
+    "id": 132031,
+    "name": "Gurdaspur",
+    "state_code": "PB"
+  },
+  {
+    "id": 132037,
+    "name": "Guru Har Sahai",
+    "state_code": "PB"
+  },
+  {
+    "id": 132136,
+    "name": "Hajipur",
+    "state_code": "PB"
+  },
+  {
+    "id": 132077,
+    "name": "Hariana",
+    "state_code": "PB"
+  },
+  {
+    "id": 132122,
+    "name": "Hoshiarpur",
+    "state_code": "PB"
+  },
+  {
+    "id": 143764,
+    "name": "Ishanpur",
+    "state_code": "PB"
+  },
+  {
+    "id": 132192,
+    "name": "Jagraon",
+    "state_code": "PB"
+  },
+  {
+    "id": 132207,
+    "name": "Jaito",
+    "state_code": "PB"
+  },
+  {
+    "id": 132223,
+    "name": "Jalalabad",
+    "state_code": "PB"
+  },
+  {
+    "id": 132211,
+    "name": "Jalandhar",
+    "state_code": "PB"
+  },
+  {
+    "id": 132236,
+    "name": "Jandiala",
+    "state_code": "PB"
+  },
+  {
+    "id": 132237,
+    "name": "Jandiala Guru",
+    "state_code": "PB"
+  },
+  {
+    "id": 132347,
+    "name": "Kalanaur",
+    "state_code": "PB"
+  },
+  {
+    "id": 132392,
+    "name": "Kapurthala",
+    "state_code": "PB"
+  },
+  {
+    "id": 132408,
+    "name": "Kartarpur",
+    "state_code": "PB"
+  },
+  {
+    "id": 132465,
+    "name": "Khamanon",
+    "state_code": "PB"
+  },
+  {
+    "id": 132469,
+    "name": "Khanna",
+    "state_code": "PB"
+  },
+  {
+    "id": 132472,
+    "name": "Kharar",
+    "state_code": "PB"
+  },
+  {
+    "id": 132491,
+    "name": "Khemkaran",
+    "state_code": "PB"
+  },
+  {
+    "id": 132591,
+    "name": "Kot Isa Khan",
+    "state_code": "PB"
+  },
+  {
+    "id": 132600,
+    "name": "Kotkapura",
+    "state_code": "PB"
+  },
+  {
+    "id": 132760,
+    "name": "Laungowal",
+    "state_code": "PB"
+  },
+  {
+    "id": 132785,
+    "name": "Ludhiana",
+    "state_code": "PB"
+  },
+  {
+    "id": 133056,
+    "name": "Machhiwara",
+    "state_code": "PB"
+  },
+  {
+    "id": 132861,
+    "name": "Majitha",
+    "state_code": "PB"
+  },
+  {
+    "id": 132862,
+    "name": "Makhu",
+    "state_code": "PB"
+  },
+  {
+    "id": 132867,
+    "name": "Malaut",
+    "state_code": "PB"
+  },
+  {
+    "id": 133066,
+    "name": "Malerkotla",
+    "state_code": "PB"
+  },
+  {
+    "id": 133082,
+    "name": "Mansa",
+    "state_code": "PB"
+  },
+  {
+    "id": 132948,
+    "name": "Maur Mandi",
+    "state_code": "PB"
+  },
+  {
+    "id": 132979,
+    "name": "Moga",
+    "state_code": "PB"
+  },
+  {
+    "id": 132980,
+    "name": "Mohali",
+    "state_code": "PB"
+  },
+  {
+    "id": 132996,
+    "name": "Morinda",
+    "state_code": "PB"
+  },
+  {
+    "id": 133017,
+    "name": "Mukerian",
+    "state_code": "PB"
+  },
+  {
+    "id": 133250,
+    "name": "Nabha",
+    "state_code": "PB"
+  },
+  {
+    "id": 133128,
+    "name": "Nakodar",
+    "state_code": "PB"
+  },
+  {
+    "id": 133147,
+    "name": "Nangal",
+    "state_code": "PB"
+  },
+  {
+    "id": 133190,
+    "name": "Nawanshahr",
+    "state_code": "PB"
+  },
+  {
+    "id": 133291,
+    "name": "Nurmahal",
+    "state_code": "PB"
+  },
+  {
+    "id": 133293,
+    "name": "Nurpur Kalan",
+    "state_code": "PB"
+  },
+  {
+    "id": 133382,
+    "name": "Pathankot",
+    "state_code": "PB"
+  },
+  {
+    "id": 133384,
+    "name": "Patiala",
+    "state_code": "PB"
+  },
+  {
+    "id": 133390,
+    "name": "Patti",
+    "state_code": "PB"
+  },
+  {
+    "id": 133431,
+    "name": "Phagwara",
+    "state_code": "PB"
+  },
+  {
+    "id": 133439,
+    "name": "Phillaur",
+    "state_code": "PB"
+  },
+  {
+    "id": 133575,
+    "name": "Qadian",
+    "state_code": "PB"
+  },
+  {
+    "id": 133662,
+    "name": "Rahon",
+    "state_code": "PB"
+  },
+  {
+    "id": 133665,
+    "name": "Raikot",
+    "state_code": "PB"
+  },
+  {
+    "id": 133670,
+    "name": "Rajasansi",
+    "state_code": "PB"
+  },
+  {
+    "id": 133681,
+    "name": "Rajpura",
+    "state_code": "PB"
+  },
+  {
+    "id": 133690,
+    "name": "Ram Das",
+    "state_code": "PB"
+  },
+  {
+    "id": 133708,
+    "name": "Rampura",
+    "state_code": "PB"
+  },
+  {
+    "id": 133654,
+    "name": "Rupnagar",
+    "state_code": "PB"
+  },
+  {
+    "id": 133772,
+    "name": "Samrala",
+    "state_code": "PB"
+  },
+  {
+    "id": 133776,
+    "name": "Sanaur",
+    "state_code": "PB"
+  },
+  {
+    "id": 133785,
+    "name": "Sangrur",
+    "state_code": "PB"
+  },
+  {
+    "id": 133804,
+    "name": "Sardulgarh",
+    "state_code": "PB"
+  },
+  {
+    "id": 133854,
+    "name": "Shahid Bhagat Singh Nagar",
+    "state_code": "PB"
+  },
+  {
+    "id": 133897,
+    "name": "Shahkot",
+    "state_code": "PB"
+  },
+  {
+    "id": 133911,
+    "name": "Sham Churasi",
+    "state_code": "PB"
+  },
+  {
+    "id": 133955,
+    "name": "Sirhind-Fategarh",
+    "state_code": "PB"
+  },
+  {
+    "id": 133019,
+    "name": "Sri Muktsar Sahib",
+    "state_code": "PB"
+  },
+  {
+    "id": 134037,
+    "name": "Sultanpur Lodhi",
+    "state_code": "PB"
+  },
+  {
+    "id": 134048,
+    "name": "Sunam",
+    "state_code": "PB"
+  },
+  {
+    "id": 134105,
+    "name": "Talwandi Bhai",
+    "state_code": "PB"
+  },
+  {
+    "id": 134106,
+    "name": "Talwara",
+    "state_code": "PB"
+  },
+  {
+    "id": 134118,
+    "name": "Tarn Taran Sahib",
+    "state_code": "PB"
+  },
+  {
+    "id": 134443,
+    "name": "Zira",
+    "state_code": "PB"
+  },
+  {
+    "id": 57584,
+    "name": "Abhaneri",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134449,
+    "name": "Abu",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134450,
+    "name": "Abu Road",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57614,
+    "name": "Ajmer",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57625,
+    "name": "Aklera",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57649,
+    "name": "Alwar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57676,
+    "name": "Amet",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57717,
+    "name": "Anta",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57722,
+    "name": "Anupgarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134466,
+    "name": "Asind",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57798,
+    "name": "Bagar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57822,
+    "name": "Bakani",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58115,
+    "name": "Bali",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58116,
+    "name": "Balotra",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58125,
+    "name": "Bandikui",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58134,
+    "name": "Banswara",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57863,
+    "name": "Baran",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58142,
+    "name": "Bari",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57874,
+    "name": "Bari Sadri",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58143,
+    "name": "Barmer",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57895,
+    "name": "Basi",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57899,
+    "name": "Basni",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57903,
+    "name": "Baswa",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57910,
+    "name": "Bayana",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57946,
+    "name": "Beawar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57917,
+    "name": "Begun",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57919,
+    "name": "Behror",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58008,
+    "name": "Bhadasar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58007,
+    "name": "Bhadra",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57964,
+    "name": "Bharatpur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57968,
+    "name": "Bhasawar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58019,
+    "name": "Bhilwara",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57983,
+    "name": "Bhindar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58023,
+    "name": "Bhinmal",
+    "state_code": "RJ"
+  },
+  {
+    "id": 57986,
+    "name": "Bhiwadi",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58004,
+    "name": "Bhuma",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58156,
+    "name": "Bikaner",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58051,
+    "name": "Bilara",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58067,
+    "name": "Bissau",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58083,
+    "name": "Borkhera",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58162,
+    "name": "Bundi",
+    "state_code": "RJ"
+  },
+  {
+    "id": 58177,
+    "name": "Chaksu",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131513,
+    "name": "Chechat",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131527,
+    "name": "Chhabra",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131539,
+    "name": "Chhapar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131536,
+    "name": "Chhoti Sadri",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131546,
+    "name": "Chidawa",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131574,
+    "name": "Chittaurgarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131614,
+    "name": "Churu",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131655,
+    "name": "Dariba",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131669,
+    "name": "Dausa",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131685,
+    "name": "Deoli",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131697,
+    "name": "Deshnoke",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131706,
+    "name": "Devgarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131730,
+    "name": "Dhaulpur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131813,
+    "name": "Didwana",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131814,
+    "name": "Dig",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131819,
+    "name": "Dungarpur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131867,
+    "name": "Fatehpur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131896,
+    "name": "Galiakot",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131908,
+    "name": "Ganganagar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131909,
+    "name": "Gangapur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132003,
+    "name": "Govindgarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132018,
+    "name": "Gulabpura",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132066,
+    "name": "Hanumangarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132097,
+    "name": "Hindaun",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132199,
+    "name": "Jahazpur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132201,
+    "name": "Jaipur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132203,
+    "name": "Jaisalmer",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132208,
+    "name": "Jaitaran",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132217,
+    "name": "Jalor",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132218,
+    "name": "Jalore",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132278,
+    "name": "Jhalawar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132276,
+    "name": "Jhalrapatan",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132273,
+    "name": "Jhunjhunun",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132284,
+    "name": "Jobner",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132286,
+    "name": "Jodhpur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132692,
+    "name": "Kaman",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132709,
+    "name": "Kanor",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132713,
+    "name": "Kapren",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132395,
+    "name": "Karanpur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132396,
+    "name": "Karauli",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132438,
+    "name": "Kekri",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132447,
+    "name": "Keshorai Patan",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132466,
+    "name": "Khandela",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132515,
+    "name": "Khanpur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132496,
+    "name": "Khetri",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132530,
+    "name": "Kishangarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132593,
+    "name": "Kota",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132604,
+    "name": "Kotputli",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132627,
+    "name": "Kuchaman",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132625,
+    "name": "Kuchera",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132738,
+    "name": "Kumher",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132667,
+    "name": "Kushalgarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132739,
+    "name": "Lachhmangarh Sikar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132788,
+    "name": "Ladnun",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132792,
+    "name": "Lakheri",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132798,
+    "name": "Lalsot",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132778,
+    "name": "Losal",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132843,
+    "name": "Mahwah",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132863,
+    "name": "Makrana",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133069,
+    "name": "Malpura",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133072,
+    "name": "Mandal",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133074,
+    "name": "Mandalgarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132900,
+    "name": "Mandawar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133078,
+    "name": "Mangrol",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132921,
+    "name": "Manohar Thana",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132922,
+    "name": "Manoharpur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132959,
+    "name": "Meethari Marwar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 132967,
+    "name": "Merta",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133102,
+    "name": "Mundwa",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133252,
+    "name": "Nadbai",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133112,
+    "name": "Nagar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133256,
+    "name": "Nagaur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133125,
+    "name": "Nainwa",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133153,
+    "name": "Napasar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133154,
+    "name": "Naraina",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133180,
+    "name": "Nasirabad",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133280,
+    "name": "Nathdwara",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133282,
+    "name": "Nawa",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133189,
+    "name": "Nawalgarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133201,
+    "name": "Neem ka Thana",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133289,
+    "name": "Nimaj",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133288,
+    "name": "Nimbahera",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133224,
+    "name": "Niwai",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133229,
+    "name": "Nohar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133231,
+    "name": "Nokha",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133311,
+    "name": "Padampur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133529,
+    "name": "Pali",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133366,
+    "name": "Partapur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133368,
+    "name": "Parvatsar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133433,
+    "name": "Phalodi",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133442,
+    "name": "Phulera",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133448,
+    "name": "Pilani",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133446,
+    "name": "Pilibangan",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133450,
+    "name": "Pindwara",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133565,
+    "name": "Pipar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133460,
+    "name": "Pirawa",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133466,
+    "name": "Pokaran",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133486,
+    "name": "Pratapgarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133516,
+    "name": "Pushkar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133589,
+    "name": "Raipur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133667,
+    "name": "Raisinghnagar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133686,
+    "name": "Rajakhera",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133672,
+    "name": "Rajaldesar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133674,
+    "name": "Rajgarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133596,
+    "name": "Rajsamand",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133695,
+    "name": "Ramganj Mandi",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133696,
+    "name": "Ramgarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133714,
+    "name": "Rani",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133614,
+    "name": "Ratangarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133725,
+    "name": "Rawatbhata",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133726,
+    "name": "Rawatsar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133736,
+    "name": "Ringas",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134058,
+    "name": "Sadri",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134064,
+    "name": "Salumbar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134068,
+    "name": "Sambhar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133771,
+    "name": "Samdari",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134071,
+    "name": "Sanchor",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133781,
+    "name": "Sangaria",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133783,
+    "name": "Sangod",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133805,
+    "name": "Sardarshahr",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133810,
+    "name": "Sarwar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133832,
+    "name": "Sawai Madhopur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133903,
+    "name": "Shahpura",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133859,
+    "name": "Sheoganj",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134086,
+    "name": "Sikar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133958,
+    "name": "Sirohi",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133978,
+    "name": "Siwana",
+    "state_code": "RJ"
+  },
+  {
+    "id": 133983,
+    "name": "Sojat",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134017,
+    "name": "Sri Dungargarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134018,
+    "name": "Sri Madhopur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134092,
+    "name": "Sujangarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134036,
+    "name": "Suket",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134046,
+    "name": "Sunel",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134094,
+    "name": "Surajgarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134097,
+    "name": "Suratgarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134098,
+    "name": "Takhatgarh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134240,
+    "name": "Taranagar",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134169,
+    "name": "Tijara",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134204,
+    "name": "Todabhim",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134205,
+    "name": "Todaraisingh",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134208,
+    "name": "Tonk",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134250,
+    "name": "Udaipur",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134258,
+    "name": "Udpura",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134283,
+    "name": "Uniara",
+    "state_code": "RJ"
+  },
+  {
+    "id": 134403,
+    "name": "Wer",
+    "state_code": "RJ"
+  },
+  {
+    "id": 131822,
+    "name": "East District",
+    "state_code": "SK"
+  },
+  {
+    "id": 131905,
+    "name": "Gangtok",
+    "state_code": "SK"
+  },
+  {
+    "id": 132041,
+    "name": "Gyalshing",
+    "state_code": "SK"
+  },
+  {
+    "id": 132293,
+    "name": "Jorethang",
+    "state_code": "SK"
+  },
+  {
+    "id": 132906,
+    "name": "Mangan",
+    "state_code": "SK"
+  },
+  {
+    "id": 133137,
+    "name": "Namchi",
+    "state_code": "SK"
+  },
+  {
+    "id": 133194,
+    "name": "Naya Bazar",
+    "state_code": "SK"
+  },
+  {
+    "id": 133235,
+    "name": "North District",
+    "state_code": "SK"
+  },
+  {
+    "id": 133609,
+    "name": "Rangpo",
+    "state_code": "SK"
+  },
+  {
+    "id": 133949,
+    "name": "Singtam",
+    "state_code": "SK"
+  },
+  {
+    "id": 134008,
+    "name": "South District",
+    "state_code": "SK"
+  },
+  {
+    "id": 134405,
+    "name": "West District",
+    "state_code": "SK"
+  },
+  {
+    "id": 57586,
+    "name": "Abiramam",
+    "state_code": "TN"
+  },
+  {
+    "id": 57594,
+    "name": "Adirampattinam",
+    "state_code": "TN"
+  },
+  {
+    "id": 57595,
+    "name": "Aduthurai",
+    "state_code": "TN"
+  },
+  {
+    "id": 57630,
+    "name": "Alagapuram",
+    "state_code": "TN"
+  },
+  {
+    "id": 57634,
+    "name": "Alandur",
+    "state_code": "TN"
+  },
+  {
+    "id": 57635,
+    "name": "Alanganallur",
+    "state_code": "TN"
+  },
+  {
+    "id": 57636,
+    "name": "Alangayam",
+    "state_code": "TN"
+  },
+  {
+    "id": 134455,
+    "name": "Alangudi",
+    "state_code": "TN"
+  },
+  {
+    "id": 134456,
+    "name": "Alangulam",
+    "state_code": "TN"
+  },
+  {
+    "id": 134457,
+    "name": "Alappakkam",
+    "state_code": "TN"
+  },
+  {
+    "id": 57648,
+    "name": "Alwa Tirunagari",
+    "state_code": "TN"
+  },
+  {
+    "id": 57667,
+    "name": "Ambasamudram",
+    "state_code": "TN"
+  },
+  {
+    "id": 57668,
+    "name": "Ambattur",
+    "state_code": "TN"
+  },
+  {
+    "id": 57671,
+    "name": "Ambur",
+    "state_code": "TN"
+  },
+  {
+    "id": 57682,
+    "name": "Ammapettai",
+    "state_code": "TN"
+  },
+  {
+    "id": 57694,
+    "name": "Anamalais",
+    "state_code": "TN"
+  },
+  {
+    "id": 134460,
+    "name": "Andippatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 57715,
+    "name": "Annamalainagar",
+    "state_code": "TN"
+  },
+  {
+    "id": 57712,
+    "name": "Annavasal",
+    "state_code": "TN"
+  },
+  {
+    "id": 57714,
+    "name": "Annur",
+    "state_code": "TN"
+  },
+  {
+    "id": 57718,
+    "name": "Anthiyur",
+    "state_code": "TN"
+  },
+  {
+    "id": 57726,
+    "name": "Arakkonam",
+    "state_code": "TN"
+  },
+  {
+    "id": 57729,
+    "name": "Arantangi",
+    "state_code": "TN"
+  },
+  {
+    "id": 57731,
+    "name": "Arcot",
+    "state_code": "TN"
+  },
+  {
+    "id": 57732,
+    "name": "Arimalam",
+    "state_code": "TN"
+  },
+  {
+    "id": 57733,
+    "name": "Ariyalur",
+    "state_code": "TN"
+  },
+  {
+    "id": 57737,
+    "name": "Arni",
+    "state_code": "TN"
+  },
+  {
+    "id": 57743,
+    "name": "Arumbavur",
+    "state_code": "TN"
+  },
+  {
+    "id": 57744,
+    "name": "Arumuganeri",
+    "state_code": "TN"
+  },
+  {
+    "id": 57745,
+    "name": "Aruppukkottai",
+    "state_code": "TN"
+  },
+  {
+    "id": 57746,
+    "name": "Aruvankad",
+    "state_code": "TN"
+  },
+  {
+    "id": 134468,
+    "name": "Attayyampatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 57763,
+    "name": "Attur",
+    "state_code": "TN"
+  },
+  {
+    "id": 57767,
+    "name": "Auroville",
+    "state_code": "TN"
+  },
+  {
+    "id": 134469,
+    "name": "Avadi",
+    "state_code": "TN"
+  },
+  {
+    "id": 57773,
+    "name": "Avinashi",
+    "state_code": "TN"
+  },
+  {
+    "id": 57775,
+    "name": "Ayakudi",
+    "state_code": "TN"
+  },
+  {
+    "id": 57776,
+    "name": "Ayyampettai",
+    "state_code": "TN"
+  },
+  {
+    "id": 57929,
+    "name": "Belur",
+    "state_code": "TN"
+  },
+  {
+    "id": 57973,
+    "name": "Bhavani",
+    "state_code": "TN"
+  },
+  {
+    "id": 58072,
+    "name": "Bodinayakkanur",
+    "state_code": "TN"
+  },
+  {
+    "id": 131515,
+    "name": "Chengam",
+    "state_code": "TN"
+  },
+  {
+    "id": 131517,
+    "name": "Chennai",
+    "state_code": "TN"
+  },
+  {
+    "id": 131518,
+    "name": "Chennimalai",
+    "state_code": "TN"
+  },
+  {
+    "id": 131522,
+    "name": "Chetput",
+    "state_code": "TN"
+  },
+  {
+    "id": 131523,
+    "name": "Chettipalaiyam",
+    "state_code": "TN"
+  },
+  {
+    "id": 131525,
+    "name": "Cheyyar",
+    "state_code": "TN"
+  },
+  {
+    "id": 131526,
+    "name": "Cheyyur",
+    "state_code": "TN"
+  },
+  {
+    "id": 131545,
+    "name": "Chidambaram",
+    "state_code": "TN"
+  },
+  {
+    "id": 131561,
+    "name": "Chingleput",
+    "state_code": "TN"
+  },
+  {
+    "id": 131562,
+    "name": "Chinna Salem",
+    "state_code": "TN"
+  },
+  {
+    "id": 131564,
+    "name": "Chinnamanur",
+    "state_code": "TN"
+  },
+  {
+    "id": 131565,
+    "name": "Chinnasekkadu",
+    "state_code": "TN"
+  },
+  {
+    "id": 131578,
+    "name": "Cholapuram",
+    "state_code": "TN"
+  },
+  {
+    "id": 131618,
+    "name": "Coimbatore",
+    "state_code": "TN"
+  },
+  {
+    "id": 131619,
+    "name": "Colachel",
+    "state_code": "TN"
+  },
+  {
+    "id": 131626,
+    "name": "Cuddalore",
+    "state_code": "TN"
+  },
+  {
+    "id": 131629,
+    "name": "Cumbum",
+    "state_code": "TN"
+  },
+  {
+    "id": 131681,
+    "name": "Denkanikota",
+    "state_code": "TN"
+  },
+  {
+    "id": 131698,
+    "name": "Desur",
+    "state_code": "TN"
+  },
+  {
+    "id": 131699,
+    "name": "Devadanappatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 131700,
+    "name": "Devakottai",
+    "state_code": "TN"
+  },
+  {
+    "id": 131711,
+    "name": "Dhali",
+    "state_code": "TN"
+  },
+  {
+    "id": 131723,
+    "name": "Dharapuram",
+    "state_code": "TN"
+  },
+  {
+    "id": 131726,
+    "name": "Dharmapuri",
+    "state_code": "TN"
+  },
+  {
+    "id": 131774,
+    "name": "Dindigul",
+    "state_code": "TN"
+  },
+  {
+    "id": 131820,
+    "name": "Dusi",
+    "state_code": "TN"
+  },
+  {
+    "id": 131834,
+    "name": "Elayirampannai",
+    "state_code": "TN"
+  },
+  {
+    "id": 131833,
+    "name": "Elumalai",
+    "state_code": "TN"
+  },
+  {
+    "id": 131837,
+    "name": "Eral",
+    "state_code": "TN"
+  },
+  {
+    "id": 131839,
+    "name": "Eraniel",
+    "state_code": "TN"
+  },
+  {
+    "id": 131841,
+    "name": "Erode",
+    "state_code": "TN"
+  },
+  {
+    "id": 131843,
+    "name": "Erumaippatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 131847,
+    "name": "Ettaiyapuram",
+    "state_code": "TN"
+  },
+  {
+    "id": 132045,
+    "name": "Gandhi Nagar",
+    "state_code": "TN"
+  },
+  {
+    "id": 131901,
+    "name": "Gangaikondan",
+    "state_code": "TN"
+  },
+  {
+    "id": 131902,
+    "name": "Gangavalli",
+    "state_code": "TN"
+  },
+  {
+    "id": 131957,
+    "name": "Gingee",
+    "state_code": "TN"
+  },
+  {
+    "id": 131961,
+    "name": "Gobichettipalayam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132008,
+    "name": "Gudalur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132011,
+    "name": "Gudiyatham",
+    "state_code": "TN"
+  },
+  {
+    "id": 132050,
+    "name": "Guduvancheri",
+    "state_code": "TN"
+  },
+  {
+    "id": 132023,
+    "name": "Gummidipundi",
+    "state_code": "TN"
+  },
+  {
+    "id": 132083,
+    "name": "Harur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132125,
+    "name": "Hosur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132153,
+    "name": "Idappadi",
+    "state_code": "TN"
+  },
+  {
+    "id": 132159,
+    "name": "Ilampillai",
+    "state_code": "TN"
+  },
+  {
+    "id": 132161,
+    "name": "Iluppur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132169,
+    "name": "Injambakkam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132172,
+    "name": "Irugur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132210,
+    "name": "Jalakandapuram",
+    "state_code": "TN"
+  },
+  {
+    "id": 132225,
+    "name": "Jalarpet",
+    "state_code": "TN"
+  },
+  {
+    "id": 132256,
+    "name": "Jayamkondacholapuram",
+    "state_code": "TN"
+  },
+  {
+    "id": 132324,
+    "name": "Kadambur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132326,
+    "name": "Kadayanallur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132343,
+    "name": "Kalakkadu",
+    "state_code": "TN"
+  },
+  {
+    "id": 132349,
+    "name": "Kalavai",
+    "state_code": "TN"
+  },
+  {
+    "id": 132352,
+    "name": "Kallakkurichchi",
+    "state_code": "TN"
+  },
+  {
+    "id": 132353,
+    "name": "Kallidaikurichi",
+    "state_code": "TN"
+  },
+  {
+    "id": 132354,
+    "name": "Kallupatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 132357,
+    "name": "Kalugumalai",
+    "state_code": "TN"
+  },
+  {
+    "id": 132367,
+    "name": "Kamuthi",
+    "state_code": "TN"
+  },
+  {
+    "id": 132368,
+    "name": "Kanadukattan",
+    "state_code": "TN"
+  },
+  {
+    "id": 132369,
+    "name": "Kancheepuram",
+    "state_code": "TN"
+  },
+  {
+    "id": 132370,
+    "name": "Kanchipuram",
+    "state_code": "TN"
+  },
+  {
+    "id": 132373,
+    "name": "Kangayam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132380,
+    "name": "Kanniyakumari",
+    "state_code": "TN"
+  },
+  {
+    "id": 132714,
+    "name": "Karaikkudi",
+    "state_code": "TN"
+  },
+  {
+    "id": 132716,
+    "name": "Karamadai",
+    "state_code": "TN"
+  },
+  {
+    "id": 132393,
+    "name": "Karambakkudi",
+    "state_code": "TN"
+  },
+  {
+    "id": 132401,
+    "name": "Kariapatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 132409,
+    "name": "Karumbakkam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132410,
+    "name": "Karur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132726,
+    "name": "Katpadi",
+    "state_code": "TN"
+  },
+  {
+    "id": 132429,
+    "name": "Kattivakkam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132728,
+    "name": "Kattupputtur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132730,
+    "name": "Kaveripatnam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132435,
+    "name": "Kayalpattinam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132436,
+    "name": "Kayattar",
+    "state_code": "TN"
+  },
+  {
+    "id": 132437,
+    "name": "Keelakarai",
+    "state_code": "TN"
+  },
+  {
+    "id": 132439,
+    "name": "Kelamangalam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132732,
+    "name": "Kil Bhuvanagiri",
+    "state_code": "TN"
+  },
+  {
+    "id": 132522,
+    "name": "Kilvelur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132733,
+    "name": "Kiranur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132538,
+    "name": "Kodaikanal",
+    "state_code": "TN"
+  },
+  {
+    "id": 132544,
+    "name": "Kodumudi",
+    "state_code": "TN"
+  },
+  {
+    "id": 132562,
+    "name": "Kombai",
+    "state_code": "TN"
+  },
+  {
+    "id": 132568,
+    "name": "Konganapuram",
+    "state_code": "TN"
+  },
+  {
+    "id": 132571,
+    "name": "Koothanallur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132576,
+    "name": "Koradachcheri",
+    "state_code": "TN"
+  },
+  {
+    "id": 132577,
+    "name": "Korampallam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132594,
+    "name": "Kotagiri",
+    "state_code": "TN"
+  },
+  {
+    "id": 132607,
+    "name": "Kottaiyur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132615,
+    "name": "Kovilpatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 132622,
+    "name": "Krishnagiri",
+    "state_code": "TN"
+  },
+  {
+    "id": 132632,
+    "name": "Kulattur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132634,
+    "name": "Kulittalai",
+    "state_code": "TN"
+  },
+  {
+    "id": 132637,
+    "name": "Kumaralingam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132638,
+    "name": "Kumbakonam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132651,
+    "name": "Kunnattur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132659,
+    "name": "Kurinjippadi",
+    "state_code": "TN"
+  },
+  {
+    "id": 132672,
+    "name": "Kuttalam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132673,
+    "name": "Kuzhithurai",
+    "state_code": "TN"
+  },
+  {
+    "id": 132754,
+    "name": "Lalgudi",
+    "state_code": "TN"
+  },
+  {
+    "id": 132807,
+    "name": "Madambakkam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132818,
+    "name": "Madipakkam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132819,
+    "name": "Madukkarai",
+    "state_code": "TN"
+  },
+  {
+    "id": 132820,
+    "name": "Madukkur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132821,
+    "name": "Madurai",
+    "state_code": "TN"
+  },
+  {
+    "id": 132822,
+    "name": "Madurantakam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132876,
+    "name": "Mallapuram",
+    "state_code": "TN"
+  },
+  {
+    "id": 132875,
+    "name": "Mallasamudram",
+    "state_code": "TN"
+  },
+  {
+    "id": 133067,
+    "name": "Mallur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132880,
+    "name": "Manali",
+    "state_code": "TN"
+  },
+  {
+    "id": 132881,
+    "name": "Manalurpettai",
+    "state_code": "TN"
+  },
+  {
+    "id": 132882,
+    "name": "Manamadurai",
+    "state_code": "TN"
+  },
+  {
+    "id": 132883,
+    "name": "Manappakkam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132884,
+    "name": "Manapparai",
+    "state_code": "TN"
+  },
+  {
+    "id": 132885,
+    "name": "Manavalakurichi",
+    "state_code": "TN"
+  },
+  {
+    "id": 132889,
+    "name": "Mandapam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132903,
+    "name": "Mangalam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132919,
+    "name": "Mannargudi",
+    "state_code": "TN"
+  },
+  {
+    "id": 132932,
+    "name": "Marakkanam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133089,
+    "name": "Marandahalli",
+    "state_code": "TN"
+  },
+  {
+    "id": 132939,
+    "name": "Masinigudi",
+    "state_code": "TN"
+  },
+  {
+    "id": 133091,
+    "name": "Mattur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132952,
+    "name": "Mayiladuthurai",
+    "state_code": "TN"
+  },
+  {
+    "id": 132965,
+    "name": "Melur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132969,
+    "name": "Mettuppalaiyam",
+    "state_code": "TN"
+  },
+  {
+    "id": 132970,
+    "name": "Mettur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133094,
+    "name": "Minjur",
+    "state_code": "TN"
+  },
+  {
+    "id": 132982,
+    "name": "Mohanur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133013,
+    "name": "Mudukulattur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133100,
+    "name": "Mulanur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133045,
+    "name": "Musiri",
+    "state_code": "TN"
+  },
+  {
+    "id": 133049,
+    "name": "Muttupet",
+    "state_code": "TN"
+  },
+  {
+    "id": 133108,
+    "name": "Naduvattam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133111,
+    "name": "Nagapattinam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133257,
+    "name": "Nagercoil",
+    "state_code": "TN"
+  },
+  {
+    "id": 133264,
+    "name": "Namagiripettai",
+    "state_code": "TN"
+  },
+  {
+    "id": 133134,
+    "name": "Namakkal",
+    "state_code": "TN"
+  },
+  {
+    "id": 133135,
+    "name": "Nambiyur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133136,
+    "name": "Nambutalai",
+    "state_code": "TN"
+  },
+  {
+    "id": 133140,
+    "name": "Nandambakkam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133148,
+    "name": "Nangavalli",
+    "state_code": "TN"
+  },
+  {
+    "id": 133149,
+    "name": "Nangilickondan",
+    "state_code": "TN"
+  },
+  {
+    "id": 133150,
+    "name": "Nanguneri",
+    "state_code": "TN"
+  },
+  {
+    "id": 133152,
+    "name": "Nannilam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133271,
+    "name": "Naravarikuppam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133181,
+    "name": "Nattam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133281,
+    "name": "Nattarasankottai",
+    "state_code": "TN"
+  },
+  {
+    "id": 133199,
+    "name": "Needamangalam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133200,
+    "name": "Neelankarai",
+    "state_code": "TN"
+  },
+  {
+    "id": 133203,
+    "name": "Negapatam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133205,
+    "name": "Nellikkuppam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133216,
+    "name": "Nilakottai",
+    "state_code": "TN"
+  },
+  {
+    "id": 133218,
+    "name": "Nilgiris",
+    "state_code": "TN"
+  },
+  {
+    "id": 133296,
+    "name": "Odugattur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133299,
+    "name": "Omalur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133301,
+    "name": "Ooty",
+    "state_code": "TN"
+  },
+  {
+    "id": 133314,
+    "name": "Padmanabhapuram",
+    "state_code": "TN"
+  },
+  {
+    "id": 133522,
+    "name": "Palakkodu",
+    "state_code": "TN"
+  },
+  {
+    "id": 133524,
+    "name": "Palamedu",
+    "state_code": "TN"
+  },
+  {
+    "id": 133323,
+    "name": "Palani",
+    "state_code": "TN"
+  },
+  {
+    "id": 133324,
+    "name": "Palavakkam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133327,
+    "name": "Palladam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133328,
+    "name": "Pallappatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 133329,
+    "name": "Pallattur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133335,
+    "name": "Pallavaram",
+    "state_code": "TN"
+  },
+  {
+    "id": 133332,
+    "name": "Pallikondai",
+    "state_code": "TN"
+  },
+  {
+    "id": 133333,
+    "name": "Pallipattu",
+    "state_code": "TN"
+  },
+  {
+    "id": 133334,
+    "name": "Pallippatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 133352,
+    "name": "Panruti",
+    "state_code": "TN"
+  },
+  {
+    "id": 133355,
+    "name": "Papanasam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133545,
+    "name": "Papireddippatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 133547,
+    "name": "Papparappatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 133356,
+    "name": "Paramagudi",
+    "state_code": "TN"
+  },
+  {
+    "id": 133392,
+    "name": "Pattukkottai",
+    "state_code": "TN"
+  },
+  {
+    "id": 133406,
+    "name": "Pennadam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133407,
+    "name": "Pennagaram",
+    "state_code": "TN"
+  },
+  {
+    "id": 133408,
+    "name": "Pennathur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133411,
+    "name": "Peraiyur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133412,
+    "name": "Perambalur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133413,
+    "name": "Peranamallur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133414,
+    "name": "Peranampattu",
+    "state_code": "TN"
+  },
+  {
+    "id": 133415,
+    "name": "Peravurani",
+    "state_code": "TN"
+  },
+  {
+    "id": 133417,
+    "name": "Periyakulam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133418,
+    "name": "Periyanayakkanpalaiyam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133419,
+    "name": "Periyanegamam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133420,
+    "name": "Periyapatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 133421,
+    "name": "Periyapattinam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133425,
+    "name": "Perundurai",
+    "state_code": "TN"
+  },
+  {
+    "id": 133426,
+    "name": "Perungudi",
+    "state_code": "TN"
+  },
+  {
+    "id": 133428,
+    "name": "Perur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133469,
+    "name": "Pollachi",
+    "state_code": "TN"
+  },
+  {
+    "id": 133470,
+    "name": "Polur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133473,
+    "name": "Ponnamaravati",
+    "state_code": "TN"
+  },
+  {
+    "id": 133475,
+    "name": "Ponneri",
+    "state_code": "TN"
+  },
+  {
+    "id": 133479,
+    "name": "Poonamalle",
+    "state_code": "TN"
+  },
+  {
+    "id": 133483,
+    "name": "Porur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133491,
+    "name": "Pudukkottai",
+    "state_code": "TN"
+  },
+  {
+    "id": 133492,
+    "name": "Puduppatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 133494,
+    "name": "Pudur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133493,
+    "name": "Puduvayal",
+    "state_code": "TN"
+  },
+  {
+    "id": 133498,
+    "name": "Puliyangudi",
+    "state_code": "TN"
+  },
+  {
+    "id": 133499,
+    "name": "Puliyur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133500,
+    "name": "Pullambadi",
+    "state_code": "TN"
+  },
+  {
+    "id": 133507,
+    "name": "Punjai Puliyampatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 133594,
+    "name": "Rajapalaiyam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133599,
+    "name": "Ramanathapuram",
+    "state_code": "TN"
+  },
+  {
+    "id": 133603,
+    "name": "Rameswaram",
+    "state_code": "TN"
+  },
+  {
+    "id": 149548,
+    "name": "Ranipet",
+    "state_code": "TN"
+  },
+  {
+    "id": 133611,
+    "name": "Rasipuram",
+    "state_code": "TN"
+  },
+  {
+    "id": 133758,
+    "name": "Saint Thomas Mount",
+    "state_code": "TN"
+  },
+  {
+    "id": 133763,
+    "name": "Salem",
+    "state_code": "TN"
+  },
+  {
+    "id": 133817,
+    "name": "Sathankulam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133819,
+    "name": "Sathyamangalam",
+    "state_code": "TN"
+  },
+  {
+    "id": 133823,
+    "name": "Sattur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134084,
+    "name": "Sayalkudi",
+    "state_code": "TN"
+  },
+  {
+    "id": 133851,
+    "name": "Seven Pagodas",
+    "state_code": "TN"
+  },
+  {
+    "id": 133883,
+    "name": "Sholinghur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133950,
+    "name": "Singanallur",
+    "state_code": "TN"
+  },
+  {
+    "id": 133945,
+    "name": "Singapperumalkovil",
+    "state_code": "TN"
+  },
+  {
+    "id": 134088,
+    "name": "Sirkazhi",
+    "state_code": "TN"
+  },
+  {
+    "id": 133968,
+    "name": "Sirumugai",
+    "state_code": "TN"
+  },
+  {
+    "id": 133974,
+    "name": "Sivaganga",
+    "state_code": "TN"
+  },
+  {
+    "id": 133975,
+    "name": "Sivagiri",
+    "state_code": "TN"
+  },
+  {
+    "id": 133976,
+    "name": "Sivakasi",
+    "state_code": "TN"
+  },
+  {
+    "id": 134026,
+    "name": "Srimushnam",
+    "state_code": "TN"
+  },
+  {
+    "id": 134030,
+    "name": "Sriperumbudur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134022,
+    "name": "Srivaikuntam",
+    "state_code": "TN"
+  },
+  {
+    "id": 134023,
+    "name": "Srivilliputhur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134035,
+    "name": "Suchindram",
+    "state_code": "TN"
+  },
+  {
+    "id": 134041,
+    "name": "Sulur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134095,
+    "name": "Surandai",
+    "state_code": "TN"
+  },
+  {
+    "id": 134057,
+    "name": "Swamimalai",
+    "state_code": "TN"
+  },
+  {
+    "id": 134108,
+    "name": "Tambaram",
+    "state_code": "TN"
+  },
+  {
+    "id": 134111,
+    "name": "Tanjore",
+    "state_code": "TN"
+  },
+  {
+    "id": 134239,
+    "name": "Taramangalam",
+    "state_code": "TN"
+  },
+  {
+    "id": 134243,
+    "name": "Tattayyangarpettai",
+    "state_code": "TN"
+  },
+  {
+    "id": 134140,
+    "name": "Thanjavur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134143,
+    "name": "Tharangambadi",
+    "state_code": "TN"
+  },
+  {
+    "id": 134146,
+    "name": "Theni",
+    "state_code": "TN"
+  },
+  {
+    "id": 134147,
+    "name": "Thenkasi",
+    "state_code": "TN"
+  },
+  {
+    "id": 134150,
+    "name": "Thirukattupalli",
+    "state_code": "TN"
+  },
+  {
+    "id": 134151,
+    "name": "Thiruthani",
+    "state_code": "TN"
+  },
+  {
+    "id": 134152,
+    "name": "Thiruvaiyaru",
+    "state_code": "TN"
+  },
+  {
+    "id": 134153,
+    "name": "Thiruvallur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134155,
+    "name": "Thiruvarur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134156,
+    "name": "Thiruvidaimaruthur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134158,
+    "name": "Thoothukudi",
+    "state_code": "TN"
+  },
+  {
+    "id": 134172,
+    "name": "Tindivanam",
+    "state_code": "TN"
+  },
+  {
+    "id": 134174,
+    "name": "Tinnanur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134178,
+    "name": "Tiruchchendur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134179,
+    "name": "Tiruchengode",
+    "state_code": "TN"
+  },
+  {
+    "id": 134180,
+    "name": "Tiruchirappalli",
+    "state_code": "TN"
+  },
+  {
+    "id": 134181,
+    "name": "Tirukkoyilur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134184,
+    "name": "Tirumullaivasal",
+    "state_code": "TN"
+  },
+  {
+    "id": 134185,
+    "name": "Tirunelveli",
+    "state_code": "TN"
+  },
+  {
+    "id": 134186,
+    "name": "Tirunelveli Kattabo",
+    "state_code": "TN"
+  },
+  {
+    "id": 134191,
+    "name": "Tiruppalaikudi",
+    "state_code": "TN"
+  },
+  {
+    "id": 134188,
+    "name": "Tirupparangunram",
+    "state_code": "TN"
+  },
+  {
+    "id": 134189,
+    "name": "Tiruppur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134190,
+    "name": "Tiruppuvanam",
+    "state_code": "TN"
+  },
+  {
+    "id": 134193,
+    "name": "Tiruttangal",
+    "state_code": "TN"
+  },
+  {
+    "id": 134196,
+    "name": "Tiruvannamalai",
+    "state_code": "TN"
+  },
+  {
+    "id": 134198,
+    "name": "Tiruvottiyur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134200,
+    "name": "Tisaiyanvilai",
+    "state_code": "TN"
+  },
+  {
+    "id": 134207,
+    "name": "Tondi",
+    "state_code": "TN"
+  },
+  {
+    "id": 134224,
+    "name": "Turaiyur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134253,
+    "name": "Udangudi",
+    "state_code": "TN"
+  },
+  {
+    "id": 134259,
+    "name": "Udumalaippettai",
+    "state_code": "TN"
+  },
+  {
+    "id": 134290,
+    "name": "Uppiliyapuram",
+    "state_code": "TN"
+  },
+  {
+    "id": 134295,
+    "name": "Usilampatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 134298,
+    "name": "Uttamapalaiyam",
+    "state_code": "TN"
+  },
+  {
+    "id": 134302,
+    "name": "Uttiramerur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134472,
+    "name": "Uttukkuli",
+    "state_code": "TN"
+  },
+  {
+    "id": 134303,
+    "name": "V.S.K.Valasai (Dindigul-Dist.)",
+    "state_code": "TN"
+  },
+  {
+    "id": 134304,
+    "name": "Vadakku Valliyur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134305,
+    "name": "Vadakku Viravanallur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134306,
+    "name": "Vadamadurai",
+    "state_code": "TN"
+  },
+  {
+    "id": 134380,
+    "name": "Vadippatti",
+    "state_code": "TN"
+  },
+  {
+    "id": 134316,
+    "name": "Valangaiman",
+    "state_code": "TN"
+  },
+  {
+    "id": 134317,
+    "name": "Valavanur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134319,
+    "name": "Vallam",
+    "state_code": "TN"
+  },
+  {
+    "id": 134320,
+    "name": "Valparai",
+    "state_code": "TN"
+  },
+  {
+    "id": 134323,
+    "name": "Vandalur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134324,
+    "name": "Vandavasi",
+    "state_code": "TN"
+  },
+  {
+    "id": 134325,
+    "name": "Vaniyambadi",
+    "state_code": "TN"
+  },
+  {
+    "id": 134384,
+    "name": "Vasudevanallur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134335,
+    "name": "Vattalkundu",
+    "state_code": "TN"
+  },
+  {
+    "id": 134337,
+    "name": "Vedaraniyam",
+    "state_code": "TN"
+  },
+  {
+    "id": 134338,
+    "name": "Vedasandur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134340,
+    "name": "Velankanni",
+    "state_code": "TN"
+  },
+  {
+    "id": 134342,
+    "name": "Vellanur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134341,
+    "name": "Vellore",
+    "state_code": "TN"
+  },
+  {
+    "id": 134343,
+    "name": "Velur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134345,
+    "name": "Vengavasal",
+    "state_code": "TN"
+  },
+  {
+    "id": 134351,
+    "name": "Vettaikkaranpudur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134352,
+    "name": "Vettavalam",
+    "state_code": "TN"
+  },
+  {
+    "id": 134355,
+    "name": "Vijayapuri",
+    "state_code": "TN"
+  },
+  {
+    "id": 134358,
+    "name": "Vikravandi",
+    "state_code": "TN"
+  },
+  {
+    "id": 134361,
+    "name": "Vilattikulam",
+    "state_code": "TN"
+  },
+  {
+    "id": 134362,
+    "name": "Villupuram",
+    "state_code": "TN"
+  },
+  {
+    "id": 134385,
+    "name": "Viraganur",
+    "state_code": "TN"
+  },
+  {
+    "id": 134366,
+    "name": "Virudhunagar",
+    "state_code": "TN"
+  },
+  {
+    "id": 134375,
+    "name": "Vriddhachalam",
+    "state_code": "TN"
+  },
+  {
+    "id": 134391,
+    "name": "Walajapet",
+    "state_code": "TN"
+  },
+  {
+    "id": 134392,
+    "name": "Wallajahbad",
+    "state_code": "TN"
+  },
+  {
+    "id": 134402,
+    "name": "Wellington",
+    "state_code": "TN"
+  },
+  {
+    "id": 134451,
+    "name": "Adilabad",
+    "state_code": "TG"
+  },
+  {
+    "id": 134454,
+    "name": "Alampur",
+    "state_code": "TG"
+  },
+  {
+    "id": 57701,
+    "name": "Andol",
+    "state_code": "TG"
+  },
+  {
+    "id": 57754,
+    "name": "Asifabad",
+    "state_code": "TG"
+  },
+  {
+    "id": 58120,
+    "name": "Balapur",
+    "state_code": "TG"
+  },
+  {
+    "id": 58133,
+    "name": "Banswada",
+    "state_code": "TG"
+  },
+  {
+    "id": 57923,
+    "name": "Bellampalli",
+    "state_code": "TG"
+  },
+  {
+    "id": 57955,
+    "name": "Bhadrachalam",
+    "state_code": "TG"
+  },
+  {
+    "id": 57952,
+    "name": "Bhadradri Kothagudem",
+    "state_code": "TG"
+  },
+  {
+    "id": 57960,
+    "name": "Bhaisa",
+    "state_code": "TG"
+  },
+  {
+    "id": 57994,
+    "name": "Bhongir",
+    "state_code": "TG"
+  },
+  {
+    "id": 58071,
+    "name": "Bodhan",
+    "state_code": "TG"
+  },
+  {
+    "id": 58194,
+    "name": "Chandur",
+    "state_code": "TG"
+  },
+  {
+    "id": 131607,
+    "name": "Chatakonda",
+    "state_code": "TG"
+  },
+  {
+    "id": 131660,
+    "name": "Dasnapur",
+    "state_code": "TG"
+  },
+  {
+    "id": 131703,
+    "name": "Devarkonda",
+    "state_code": "TG"
+  },
+  {
+    "id": 131789,
+    "name": "Dornakal",
+    "state_code": "TG"
+  },
+  {
+    "id": 131857,
+    "name": "Farrukhnagar",
+    "state_code": "TG"
+  },
+  {
+    "id": 131887,
+    "name": "Gaddi Annaram",
+    "state_code": "TG"
+  },
+  {
+    "id": 131890,
+    "name": "Gadwal",
+    "state_code": "TG"
+  },
+  {
+    "id": 131939,
+    "name": "Ghatkesar",
+    "state_code": "TG"
+  },
+  {
+    "id": 131989,
+    "name": "Gopalur",
+    "state_code": "TG"
+  },
+  {
+    "id": 132052,
+    "name": "Gudur",
+    "state_code": "TG"
+  },
+  {
+    "id": 132132,
+    "name": "Hyderabad",
+    "state_code": "TG"
+  },
+  {
+    "id": 132193,
+    "name": "Jagtial",
+    "state_code": "TG"
+  },
+  {
+    "id": 132238,
+    "name": "Jangaon",
+    "state_code": "TG"
+  },
+  {
+    "id": 132257,
+    "name": "Jayashankar Bhupalapally",
+    "state_code": "TG"
+  },
+  {
+    "id": 132290,
+    "name": "Jogulamba Gadwal",
+    "state_code": "TG"
+  },
+  {
+    "id": 132331,
+    "name": "Kagaznagar",
+    "state_code": "TG"
+  },
+  {
+    "id": 132696,
+    "name": "Kamareddi",
+    "state_code": "TG"
+  },
+  {
+    "id": 132363,
+    "name": "Kamareddy",
+    "state_code": "TG"
+  },
+  {
+    "id": 132415,
+    "name": "Karimnagar",
+    "state_code": "TG"
+  },
+  {
+    "id": 132464,
+    "name": "Khammam",
+    "state_code": "TG"
+  },
+  {
+    "id": 132546,
+    "name": "Kodar",
+    "state_code": "TG"
+  },
+  {
+    "id": 132580,
+    "name": "Koratla",
+    "state_code": "TG"
+  },
+  {
+    "id": 132599,
+    "name": "Kothapet",
+    "state_code": "TG"
+  },
+  {
+    "id": 132606,
+    "name": "Kottagudem",
+    "state_code": "TG"
+  },
+  {
+    "id": 132608,
+    "name": "Kottapalli",
+    "state_code": "TG"
+  },
+  {
+    "id": 132737,
+    "name": "Kukatpally",
+    "state_code": "TG"
+  },
+  {
+    "id": 132674,
+    "name": "Kyathampalle",
+    "state_code": "TG"
+  },
+  {
+    "id": 132751,
+    "name": "Lakshettipet",
+    "state_code": "TG"
+  },
+  {
+    "id": 132753,
+    "name": "Lal Bahadur Nagar",
+    "state_code": "TG"
+  },
+  {
+    "id": 132824,
+    "name": "Mahabubabad",
+    "state_code": "TG"
+  },
+  {
+    "id": 132828,
+    "name": "Mahbubnagar",
+    "state_code": "TG"
+  },
+  {
+    "id": 132870,
+    "name": "Malkajgiri",
+    "state_code": "TG"
+  },
+  {
+    "id": 132887,
+    "name": "Mancheral",
+    "state_code": "TG"
+  },
+  {
+    "id": 132888,
+    "name": "Mandamarri",
+    "state_code": "TG"
+  },
+  {
+    "id": 132927,
+    "name": "Manthani",
+    "state_code": "TG"
+  },
+  {
+    "id": 132928,
+    "name": "Manuguru",
+    "state_code": "TG"
+  },
+  {
+    "id": 132955,
+    "name": "Medak",
+    "state_code": "TG"
+  },
+  {
+    "id": 132956,
+    "name": "Medchal",
+    "state_code": "TG"
+  },
+  {
+    "id": 132957,
+    "name": "Medchal Malkajgiri",
+    "state_code": "TG"
+  },
+  {
+    "id": 132975,
+    "name": "Mirialguda",
+    "state_code": "TG"
+  },
+  {
+    "id": 133255,
+    "name": "Nagar Karnul",
+    "state_code": "TG"
+  },
+  {
+    "id": 133132,
+    "name": "Nalgonda",
+    "state_code": "TG"
+  },
+  {
+    "id": 133277,
+    "name": "Narayanpet",
+    "state_code": "TG"
+  },
+  {
+    "id": 133274,
+    "name": "Narsingi",
+    "state_code": "TG"
+  },
+  {
+    "id": 133278,
+    "name": "Naspur",
+    "state_code": "TG"
+  },
+  {
+    "id": 133221,
+    "name": "Nirmal",
+    "state_code": "TG"
+  },
+  {
+    "id": 133226,
+    "name": "Nizamabad",
+    "state_code": "TG"
+  },
+  {
+    "id": 133535,
+    "name": "Paloncha",
+    "state_code": "TG"
+  },
+  {
+    "id": 133338,
+    "name": "Palwancha",
+    "state_code": "TG"
+  },
+  {
+    "id": 133377,
+    "name": "Patancheru",
+    "state_code": "TG"
+  },
+  {
+    "id": 133401,
+    "name": "Peddapalli",
+    "state_code": "TG"
+  },
+  {
+    "id": 133574,
+    "name": "Quthbullapur",
+    "state_code": "TG"
+  },
+  {
+    "id": 133592,
+    "name": "Rajanna Sircilla",
+    "state_code": "TG"
+  },
+  {
+    "id": 133597,
+    "name": "Ramagundam",
+    "state_code": "TG"
+  },
+  {
+    "id": 133699,
+    "name": "Ramgundam",
+    "state_code": "TG"
+  },
+  {
+    "id": 133607,
+    "name": "Rangareddi",
+    "state_code": "TG"
+  },
+  {
+    "id": 133745,
+    "name": "Sadaseopet",
+    "state_code": "TG"
+  },
+  {
+    "id": 133787,
+    "name": "Sangareddi",
+    "state_code": "TG"
+  },
+  {
+    "id": 133818,
+    "name": "Sathupalli",
+    "state_code": "TG"
+  },
+  {
+    "id": 133834,
+    "name": "Secunderabad",
+    "state_code": "TG"
+  },
+  {
+    "id": 133849,
+    "name": "Serilingampalle",
+    "state_code": "TG"
+  },
+  {
+    "id": 133919,
+    "name": "Siddipet",
+    "state_code": "TG"
+  },
+  {
+    "id": 133951,
+    "name": "Singapur",
+    "state_code": "TG"
+  },
+  {
+    "id": 133960,
+    "name": "Sirpur",
+    "state_code": "TG"
+  },
+  {
+    "id": 133964,
+    "name": "Sirsilla",
+    "state_code": "TG"
+  },
+  {
+    "id": 134031,
+    "name": "Sriramnagar",
+    "state_code": "TG"
+  },
+  {
+    "id": 134054,
+    "name": "Suriapet",
+    "state_code": "TG"
+  },
+  {
+    "id": 134237,
+    "name": "Tandur",
+    "state_code": "TG"
+  },
+  {
+    "id": 134287,
+    "name": "Uppal Kalan",
+    "state_code": "TG"
+  },
+  {
+    "id": 134344,
+    "name": "Vemalwada",
+    "state_code": "TG"
+  },
+  {
+    "id": 134359,
+    "name": "Vikarabad",
+    "state_code": "TG"
+  },
+  {
+    "id": 134394,
+    "name": "Wanparti",
+    "state_code": "TG"
+  },
+  {
+    "id": 134395,
+    "name": "Warangal",
+    "state_code": "TG"
+  },
+  {
+    "id": 134432,
+    "name": "Yellandu",
+    "state_code": "TG"
+  },
+  {
+    "id": 134440,
+    "name": "Zahirabad",
+    "state_code": "TG"
+  },
+  {
+    "id": 57600,
+    "name": "Agartala",
+    "state_code": "TR"
+  },
+  {
+    "id": 57662,
+    "name": "Amarpur",
+    "state_code": "TR"
+  },
+  {
+    "id": 134458,
+    "name": "Ambasa",
+    "state_code": "TR"
+  },
+  {
+    "id": 57876,
+    "name": "Barjala",
+    "state_code": "TR"
+  },
+  {
+    "id": 57926,
+    "name": "Belonia",
+    "state_code": "TR"
+  },
+  {
+    "id": 131710,
+    "name": "Dhalai",
+    "state_code": "TR"
+  },
+  {
+    "id": 131725,
+    "name": "Dharmanagar",
+    "state_code": "TR"
+  },
+  {
+    "id": 131979,
+    "name": "Gomati",
+    "state_code": "TR"
+  },
+  {
+    "id": 132334,
+    "name": "Kailashahar",
+    "state_code": "TR"
+  },
+  {
+    "id": 132362,
+    "name": "Kamalpur",
+    "state_code": "TR"
+  },
+  {
+    "id": 132502,
+    "name": "Khowai",
+    "state_code": "TR"
+  },
+  {
+    "id": 133241,
+    "name": "North Tripura",
+    "state_code": "TR"
+  },
+  {
+    "id": 133721,
+    "name": "Ranir Bazar",
+    "state_code": "TR"
+  },
+  {
+    "id": 133740,
+    "name": "Sabrum",
+    "state_code": "TR"
+  },
+  {
+    "id": 133997,
+    "name": "Sonamura",
+    "state_code": "TR"
+  },
+  {
+    "id": 134011,
+    "name": "South Tripura",
+    "state_code": "TR"
+  },
+  {
+    "id": 134249,
+    "name": "Udaipur",
+    "state_code": "TR"
+  },
+  {
+    "id": 134281,
+    "name": "Unakoti",
+    "state_code": "TR"
+  },
+  {
+    "id": 134412,
+    "name": "West Tripura",
+    "state_code": "TR"
+  },
+  {
+    "id": 57590,
+    "name": "Achhnera",
+    "state_code": "UP"
+  },
+  {
+    "id": 57597,
+    "name": "Afzalgarh",
+    "state_code": "UP"
+  },
+  {
+    "id": 57601,
+    "name": "Agra",
+    "state_code": "UP"
+  },
+  {
+    "id": 57607,
+    "name": "Ahraura",
+    "state_code": "UP"
+  },
+  {
+    "id": 147426,
+    "name": "Aidalpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147427,
+    "name": "Airwa",
+    "state_code": "UP"
+  },
+  {
+    "id": 57621,
+    "name": "Akbarpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147428,
+    "name": "Akola",
+    "state_code": "UP"
+  },
+  {
+    "id": 57653,
+    "name": "Aliganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 57654,
+    "name": "Aligarh",
+    "state_code": "UP"
+  },
+  {
+    "id": 147429,
+    "name": "Allahabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 57641,
+    "name": "Allahganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 57692,
+    "name": "Amanpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147430,
+    "name": "Amauli",
+    "state_code": "UP"
+  },
+  {
+    "id": 57666,
+    "name": "Ambahta",
+    "state_code": "UP"
+  },
+  {
+    "id": 57669,
+    "name": "Ambedkar Nagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 57677,
+    "name": "Amethi",
+    "state_code": "UP"
+  },
+  {
+    "id": 57687,
+    "name": "Amroha",
+    "state_code": "UP"
+  },
+  {
+    "id": 57696,
+    "name": "Anandnagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 57720,
+    "name": "Antu",
+    "state_code": "UP"
+  },
+  {
+    "id": 57724,
+    "name": "Anupshahr",
+    "state_code": "UP"
+  },
+  {
+    "id": 57725,
+    "name": "Aonla",
+    "state_code": "UP"
+  },
+  {
+    "id": 147431,
+    "name": "Araul",
+    "state_code": "UP"
+  },
+  {
+    "id": 147432,
+    "name": "Asalatganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 57755,
+    "name": "Atarra",
+    "state_code": "UP"
+  },
+  {
+    "id": 57760,
+    "name": "Atrauli",
+    "state_code": "UP"
+  },
+  {
+    "id": 57759,
+    "name": "Atraulia",
+    "state_code": "UP"
+  },
+  {
+    "id": 57764,
+    "name": "Auraiya",
+    "state_code": "UP"
+  },
+  {
+    "id": 57769,
+    "name": "Auras",
+    "state_code": "UP"
+  },
+  {
+    "id": 57616,
+    "name": "Ayodhya",
+    "state_code": "UP"
+  },
+  {
+    "id": 57777,
+    "name": "Azamgarh",
+    "state_code": "UP"
+  },
+  {
+    "id": 147433,
+    "name": "Azizpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 57779,
+    "name": "Baberu",
+    "state_code": "UP"
+  },
+  {
+    "id": 57782,
+    "name": "Babina",
+    "state_code": "UP"
+  },
+  {
+    "id": 57780,
+    "name": "Babrala",
+    "state_code": "UP"
+  },
+  {
+    "id": 57781,
+    "name": "Babugarh",
+    "state_code": "UP"
+  },
+  {
+    "id": 57783,
+    "name": "Bachhraon",
+    "state_code": "UP"
+  },
+  {
+    "id": 57784,
+    "name": "Bachhrawan",
+    "state_code": "UP"
+  },
+  {
+    "id": 57801,
+    "name": "Baghpat",
+    "state_code": "UP"
+  },
+  {
+    "id": 147434,
+    "name": "Baghra",
+    "state_code": "UP"
+  },
+  {
+    "id": 58112,
+    "name": "Bah",
+    "state_code": "UP"
+  },
+  {
+    "id": 57803,
+    "name": "Baheri",
+    "state_code": "UP"
+  },
+  {
+    "id": 57804,
+    "name": "Bahjoi",
+    "state_code": "UP"
+  },
+  {
+    "id": 57805,
+    "name": "Bahraich",
+    "state_code": "UP"
+  },
+  {
+    "id": 57806,
+    "name": "Bahraigh",
+    "state_code": "UP"
+  },
+  {
+    "id": 57807,
+    "name": "Bahsuma",
+    "state_code": "UP"
+  },
+  {
+    "id": 57808,
+    "name": "Bahua",
+    "state_code": "UP"
+  },
+  {
+    "id": 58113,
+    "name": "Bajna",
+    "state_code": "UP"
+  },
+  {
+    "id": 57817,
+    "name": "Bakewar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147435,
+    "name": "Baksar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147436,
+    "name": "Balamau",
+    "state_code": "UP"
+  },
+  {
+    "id": 147437,
+    "name": "Baldeo",
+    "state_code": "UP"
+  },
+  {
+    "id": 57825,
+    "name": "Baldev",
+    "state_code": "UP"
+  },
+  {
+    "id": 57828,
+    "name": "Ballia",
+    "state_code": "UP"
+  },
+  {
+    "id": 57833,
+    "name": "Balrampur",
+    "state_code": "UP"
+  },
+  {
+    "id": 57840,
+    "name": "Banat",
+    "state_code": "UP"
+  },
+  {
+    "id": 57841,
+    "name": "Banbasa",
+    "state_code": "UP"
+  },
+  {
+    "id": 58124,
+    "name": "Banda",
+    "state_code": "UP"
+  },
+  {
+    "id": 58126,
+    "name": "Bangarmau",
+    "state_code": "UP"
+  },
+  {
+    "id": 58130,
+    "name": "Bansdih",
+    "state_code": "UP"
+  },
+  {
+    "id": 58131,
+    "name": "Bansgaon",
+    "state_code": "UP"
+  },
+  {
+    "id": 58132,
+    "name": "Bansi",
+    "state_code": "UP"
+  },
+  {
+    "id": 147438,
+    "name": "Banthra",
+    "state_code": "UP"
+  },
+  {
+    "id": 58138,
+    "name": "Bara Banki",
+    "state_code": "UP"
+  },
+  {
+    "id": 57892,
+    "name": "Baragaon",
+    "state_code": "UP"
+  },
+  {
+    "id": 57865,
+    "name": "Baraut",
+    "state_code": "UP"
+  },
+  {
+    "id": 57867,
+    "name": "Bareilly",
+    "state_code": "UP"
+  },
+  {
+    "id": 147439,
+    "name": "Barhalganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 147440,
+    "name": "Barkhera",
+    "state_code": "UP"
+  },
+  {
+    "id": 57877,
+    "name": "Barkhera Kalan",
+    "state_code": "UP"
+  },
+  {
+    "id": 147441,
+    "name": "Barokhar",
+    "state_code": "UP"
+  },
+  {
+    "id": 57887,
+    "name": "Barsana",
+    "state_code": "UP"
+  },
+  {
+    "id": 147442,
+    "name": "Barwar (Lakhimpur Kheri)",
+    "state_code": "UP"
+  },
+  {
+    "id": 57901,
+    "name": "Basti",
+    "state_code": "UP"
+  },
+  {
+    "id": 57918,
+    "name": "Behat",
+    "state_code": "UP"
+  },
+  {
+    "id": 57920,
+    "name": "Bela",
+    "state_code": "UP"
+  },
+  {
+    "id": 147443,
+    "name": "Belthara",
+    "state_code": "UP"
+  },
+  {
+    "id": 57934,
+    "name": "Beniganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 57938,
+    "name": "Beswan",
+    "state_code": "UP"
+  },
+  {
+    "id": 57944,
+    "name": "Bewar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147444,
+    "name": "Bhadarsa",
+    "state_code": "UP"
+  },
+  {
+    "id": 57951,
+    "name": "Bhadohi",
+    "state_code": "UP"
+  },
+  {
+    "id": 57958,
+    "name": "Bhagwantnagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147445,
+    "name": "Bharatpura",
+    "state_code": "UP"
+  },
+  {
+    "id": 147446,
+    "name": "Bhargain",
+    "state_code": "UP"
+  },
+  {
+    "id": 57965,
+    "name": "Bharthana",
+    "state_code": "UP"
+  },
+  {
+    "id": 57966,
+    "name": "Bharwari",
+    "state_code": "UP"
+  },
+  {
+    "id": 147447,
+    "name": "Bhaupur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147448,
+    "name": "Bhimtal",
+    "state_code": "UP"
+  },
+  {
+    "id": 57984,
+    "name": "Bhinga",
+    "state_code": "UP"
+  },
+  {
+    "id": 147449,
+    "name": "Bhognipur",
+    "state_code": "UP"
+  },
+  {
+    "id": 57993,
+    "name": "Bhongaon",
+    "state_code": "UP"
+  },
+  {
+    "id": 147450,
+    "name": "Bidhnu",
+    "state_code": "UP"
+  },
+  {
+    "id": 58027,
+    "name": "Bidhuna",
+    "state_code": "UP"
+  },
+  {
+    "id": 147451,
+    "name": "Bighapur",
+    "state_code": "UP"
+  },
+  {
+    "id": 58155,
+    "name": "Bighapur Khurd",
+    "state_code": "UP"
+  },
+  {
+    "id": 58035,
+    "name": "Bijnor",
+    "state_code": "UP"
+  },
+  {
+    "id": 58158,
+    "name": "Bikapur",
+    "state_code": "UP"
+  },
+  {
+    "id": 58052,
+    "name": "Bilari",
+    "state_code": "UP"
+  },
+  {
+    "id": 58040,
+    "name": "Bilariaganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 58159,
+    "name": "Bilaspur",
+    "state_code": "UP"
+  },
+  {
+    "id": 58043,
+    "name": "Bilgram",
+    "state_code": "UP"
+  },
+  {
+    "id": 58044,
+    "name": "Bilhaur",
+    "state_code": "UP"
+  },
+  {
+    "id": 58048,
+    "name": "Bilsanda",
+    "state_code": "UP"
+  },
+  {
+    "id": 58049,
+    "name": "Bilsi",
+    "state_code": "UP"
+  },
+  {
+    "id": 58050,
+    "name": "Bilthra",
+    "state_code": "UP"
+  },
+  {
+    "id": 147452,
+    "name": "Binauli",
+    "state_code": "UP"
+  },
+  {
+    "id": 147453,
+    "name": "Binaur",
+    "state_code": "UP"
+  },
+  {
+    "id": 58057,
+    "name": "Bindki",
+    "state_code": "UP"
+  },
+  {
+    "id": 147454,
+    "name": "Birdpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147455,
+    "name": "Birpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 58161,
+    "name": "Bisalpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147456,
+    "name": "Bisanda Buzurg",
+    "state_code": "UP"
+  },
+  {
+    "id": 58062,
+    "name": "Bisauli",
+    "state_code": "UP"
+  },
+  {
+    "id": 58063,
+    "name": "Bisenda Buzurg",
+    "state_code": "UP"
+  },
+  {
+    "id": 58066,
+    "name": "Bishunpur Urf Maharajganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 58068,
+    "name": "Biswan",
+    "state_code": "UP"
+  },
+  {
+    "id": 58069,
+    "name": "Bithur",
+    "state_code": "UP"
+  },
+  {
+    "id": 58088,
+    "name": "Budaun",
+    "state_code": "UP"
+  },
+  {
+    "id": 58091,
+    "name": "Budhana",
+    "state_code": "UP"
+  },
+  {
+    "id": 58093,
+    "name": "Bulandshahr",
+    "state_code": "UP"
+  },
+  {
+    "id": 58168,
+    "name": "Captainganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 58172,
+    "name": "Chail",
+    "state_code": "UP"
+  },
+  {
+    "id": 58173,
+    "name": "Chakia",
+    "state_code": "UP"
+  },
+  {
+    "id": 58186,
+    "name": "Chandauli",
+    "state_code": "UP"
+  },
+  {
+    "id": 58187,
+    "name": "Chandauli District",
+    "state_code": "UP"
+  },
+  {
+    "id": 147457,
+    "name": "Chandausi",
+    "state_code": "UP"
+  },
+  {
+    "id": 131600,
+    "name": "Chandpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 58193,
+    "name": "Chanduasi",
+    "state_code": "UP"
+  },
+  {
+    "id": 58201,
+    "name": "Charkhari",
+    "state_code": "UP"
+  },
+  {
+    "id": 131509,
+    "name": "Charthawal",
+    "state_code": "UP"
+  },
+  {
+    "id": 131530,
+    "name": "Chhaprauli",
+    "state_code": "UP"
+  },
+  {
+    "id": 131531,
+    "name": "Chharra",
+    "state_code": "UP"
+  },
+  {
+    "id": 131540,
+    "name": "Chhata",
+    "state_code": "UP"
+  },
+  {
+    "id": 131533,
+    "name": "Chhibramau",
+    "state_code": "UP"
+  },
+  {
+    "id": 147458,
+    "name": "Chhitauni",
+    "state_code": "UP"
+  },
+  {
+    "id": 131537,
+    "name": "Chhutmalpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 131557,
+    "name": "Chillupar",
+    "state_code": "UP"
+  },
+  {
+    "id": 131569,
+    "name": "Chirgaon",
+    "state_code": "UP"
+  },
+  {
+    "id": 131572,
+    "name": "Chitrakoot",
+    "state_code": "UP"
+  },
+  {
+    "id": 147459,
+    "name": "Chitrakoot Dham",
+    "state_code": "UP"
+  },
+  {
+    "id": 131579,
+    "name": "Chopan",
+    "state_code": "UP"
+  },
+  {
+    "id": 131584,
+    "name": "Chunar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147460,
+    "name": "Churk",
+    "state_code": "UP"
+  },
+  {
+    "id": 131621,
+    "name": "Colonelganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 131806,
+    "name": "Dadri",
+    "state_code": "UP"
+  },
+  {
+    "id": 131646,
+    "name": "Dalmau",
+    "state_code": "UP"
+  },
+  {
+    "id": 131653,
+    "name": "Dankaur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147461,
+    "name": "Daraganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 147462,
+    "name": "Daranagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 131811,
+    "name": "Dasna",
+    "state_code": "UP"
+  },
+  {
+    "id": 131812,
+    "name": "Dataganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 131668,
+    "name": "Daurala",
+    "state_code": "UP"
+  },
+  {
+    "id": 131674,
+    "name": "Dayal Bagh",
+    "state_code": "UP"
+  },
+  {
+    "id": 131682,
+    "name": "Deoband",
+    "state_code": "UP"
+  },
+  {
+    "id": 147463,
+    "name": "Deogarh",
+    "state_code": "UP"
+  },
+  {
+    "id": 131689,
+    "name": "Deoranian",
+    "state_code": "UP"
+  },
+  {
+    "id": 131692,
+    "name": "Deoria",
+    "state_code": "UP"
+  },
+  {
+    "id": 147464,
+    "name": "Derapur",
+    "state_code": "UP"
+  },
+  {
+    "id": 131708,
+    "name": "Dewa",
+    "state_code": "UP"
+  },
+  {
+    "id": 131750,
+    "name": "Dhampur",
+    "state_code": "UP"
+  },
+  {
+    "id": 131714,
+    "name": "Dhanaura",
+    "state_code": "UP"
+  },
+  {
+    "id": 147465,
+    "name": "Dhanghata",
+    "state_code": "UP"
+  },
+  {
+    "id": 147466,
+    "name": "Dharau",
+    "state_code": "UP"
+  },
+  {
+    "id": 131731,
+    "name": "Dhaurahra",
+    "state_code": "UP"
+  },
+  {
+    "id": 131761,
+    "name": "Dibai",
+    "state_code": "UP"
+  },
+  {
+    "id": 147467,
+    "name": "Divrasai",
+    "state_code": "UP"
+  },
+  {
+    "id": 131783,
+    "name": "Dohrighat",
+    "state_code": "UP"
+  },
+  {
+    "id": 147468,
+    "name": "Domariaganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 131791,
+    "name": "Dostpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 131818,
+    "name": "Dudhi",
+    "state_code": "UP"
+  },
+  {
+    "id": 131845,
+    "name": "Etah",
+    "state_code": "UP"
+  },
+  {
+    "id": 131849,
+    "name": "Etawah",
+    "state_code": "UP"
+  },
+  {
+    "id": 147469,
+    "name": "Etmadpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 131851,
+    "name": "Faizabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 131852,
+    "name": "Farah",
+    "state_code": "UP"
+  },
+  {
+    "id": 131860,
+    "name": "Faridnagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 131861,
+    "name": "Faridpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 131858,
+    "name": "Farrukhabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 131871,
+    "name": "Fatehabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 131863,
+    "name": "Fatehganj West",
+    "state_code": "UP"
+  },
+  {
+    "id": 131864,
+    "name": "Fatehgarh",
+    "state_code": "UP"
+  },
+  {
+    "id": 131868,
+    "name": "Fatehpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147470,
+    "name": "Fatehpur (Barabanki)",
+    "state_code": "UP"
+  },
+  {
+    "id": 131869,
+    "name": "Fatehpur Chaurasi",
+    "state_code": "UP"
+  },
+  {
+    "id": 131870,
+    "name": "Fatehpur Sikri",
+    "state_code": "UP"
+  },
+  {
+    "id": 131876,
+    "name": "Firozabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 131880,
+    "name": "Fyzabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 147471,
+    "name": "Gahlon",
+    "state_code": "UP"
+  },
+  {
+    "id": 147472,
+    "name": "Gahmar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147473,
+    "name": "Gaini",
+    "state_code": "UP"
+  },
+  {
+    "id": 131894,
+    "name": "Gajraula",
+    "state_code": "UP"
+  },
+  {
+    "id": 131903,
+    "name": "Gangoh",
+    "state_code": "UP"
+  },
+  {
+    "id": 147474,
+    "name": "Ganj Dundawara",
+    "state_code": "UP"
+  },
+  {
+    "id": 131912,
+    "name": "Ganj Dundwara",
+    "state_code": "UP"
+  },
+  {
+    "id": 131913,
+    "name": "Ganj Muradabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 131916,
+    "name": "Garautha",
+    "state_code": "UP"
+  },
+  {
+    "id": 131919,
+    "name": "Garhi Pukhta",
+    "state_code": "UP"
+  },
+  {
+    "id": 131920,
+    "name": "Garhmuktesar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147475,
+    "name": "Garhwa",
+    "state_code": "UP"
+  },
+  {
+    "id": 147476,
+    "name": "Gauriganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 131929,
+    "name": "Gautam Buddha Nagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 131931,
+    "name": "Gawan",
+    "state_code": "UP"
+  },
+  {
+    "id": 131950,
+    "name": "Ghatampur",
+    "state_code": "UP"
+  },
+  {
+    "id": 131953,
+    "name": "Ghaziabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 131940,
+    "name": "Ghazipur",
+    "state_code": "UP"
+  },
+  {
+    "id": 131941,
+    "name": "Ghiror",
+    "state_code": "UP"
+  },
+  {
+    "id": 131945,
+    "name": "Ghorawal",
+    "state_code": "UP"
+  },
+  {
+    "id": 131946,
+    "name": "Ghosi",
+    "state_code": "UP"
+  },
+  {
+    "id": 131969,
+    "name": "Gohand",
+    "state_code": "UP"
+  },
+  {
+    "id": 131973,
+    "name": "Gokul",
+    "state_code": "UP"
+  },
+  {
+    "id": 131974,
+    "name": "Gola Bazar",
+    "state_code": "UP"
+  },
+  {
+    "id": 131975,
+    "name": "Gola Gokarannath",
+    "state_code": "UP"
+  },
+  {
+    "id": 131981,
+    "name": "Gonda",
+    "state_code": "UP"
+  },
+  {
+    "id": 131990,
+    "name": "Gopamau",
+    "state_code": "UP"
+  },
+  {
+    "id": 131992,
+    "name": "Gorakhpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147478,
+    "name": "Gosainganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 131998,
+    "name": "Goshainganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 132000,
+    "name": "Govardhan",
+    "state_code": "UP"
+  },
+  {
+    "id": 132005,
+    "name": "Greater Noida",
+    "state_code": "UP"
+  },
+  {
+    "id": 132019,
+    "name": "Gulaothi",
+    "state_code": "UP"
+  },
+  {
+    "id": 132026,
+    "name": "Gunnaur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132035,
+    "name": "Gursahaiganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 132036,
+    "name": "Gursarai",
+    "state_code": "UP"
+  },
+  {
+    "id": 132042,
+    "name": "Gyanpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132057,
+    "name": "Haldaur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132062,
+    "name": "Hamirpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132064,
+    "name": "Handia",
+    "state_code": "UP"
+  },
+  {
+    "id": 132142,
+    "name": "Hapur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147479,
+    "name": "Haraipur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132068,
+    "name": "Haraiya",
+    "state_code": "UP"
+  },
+  {
+    "id": 147480,
+    "name": "Harchandpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132072,
+    "name": "Hardoi",
+    "state_code": "UP"
+  },
+  {
+    "id": 132074,
+    "name": "Harduaganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 132085,
+    "name": "Hasanpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132087,
+    "name": "Hastinapur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132146,
+    "name": "Hata",
+    "state_code": "UP"
+  },
+  {
+    "id": 147481,
+    "name": "Hata (India)",
+    "state_code": "UP"
+  },
+  {
+    "id": 132144,
+    "name": "Hathras",
+    "state_code": "UP"
+  },
+  {
+    "id": 147482,
+    "name": "Hulas",
+    "state_code": "UP"
+  },
+  {
+    "id": 147483,
+    "name": "Ibrahimpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132156,
+    "name": "Iglas",
+    "state_code": "UP"
+  },
+  {
+    "id": 132157,
+    "name": "Ikauna",
+    "state_code": "UP"
+  },
+  {
+    "id": 132164,
+    "name": "Indergarh",
+    "state_code": "UP"
+  },
+  {
+    "id": 147484,
+    "name": "Indragarh",
+    "state_code": "UP"
+  },
+  {
+    "id": 132173,
+    "name": "Islamnagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147485,
+    "name": "Islamnagar (Badaun)",
+    "state_code": "UP"
+  },
+  {
+    "id": 132176,
+    "name": "Itaunja",
+    "state_code": "UP"
+  },
+  {
+    "id": 132177,
+    "name": "Itimadpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132187,
+    "name": "Jagdishpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132191,
+    "name": "Jagnair",
+    "state_code": "UP"
+  },
+  {
+    "id": 132197,
+    "name": "Jahanabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 147486,
+    "name": "Jahanabad (Pilibhit)",
+    "state_code": "UP"
+  },
+  {
+    "id": 132196,
+    "name": "Jahangirabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 132195,
+    "name": "Jahangirpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132200,
+    "name": "Jainpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132202,
+    "name": "Jais",
+    "state_code": "UP"
+  },
+  {
+    "id": 132221,
+    "name": "Jalalabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 132224,
+    "name": "Jalali",
+    "state_code": "UP"
+  },
+  {
+    "id": 132220,
+    "name": "Jalalpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132306,
+    "name": "Jalaun",
+    "state_code": "UP"
+  },
+  {
+    "id": 132212,
+    "name": "Jalesar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147487,
+    "name": "Janghai",
+    "state_code": "UP"
+  },
+  {
+    "id": 132313,
+    "name": "Jansath",
+    "state_code": "UP"
+  },
+  {
+    "id": 147488,
+    "name": "Jarwa",
+    "state_code": "UP"
+  },
+  {
+    "id": 132242,
+    "name": "Jarwal",
+    "state_code": "UP"
+  },
+  {
+    "id": 132248,
+    "name": "Jasrana",
+    "state_code": "UP"
+  },
+  {
+    "id": 132249,
+    "name": "Jaswantnagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 132252,
+    "name": "Jaunpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132264,
+    "name": "Jewar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147489,
+    "name": "Jhajhar",
+    "state_code": "UP"
+  },
+  {
+    "id": 132277,
+    "name": "Jhalu",
+    "state_code": "UP"
+  },
+  {
+    "id": 132279,
+    "name": "Jhansi",
+    "state_code": "UP"
+  },
+  {
+    "id": 132280,
+    "name": "Jhinjhak",
+    "state_code": "UP"
+  },
+  {
+    "id": 132271,
+    "name": "Jhinjhana",
+    "state_code": "UP"
+  },
+  {
+    "id": 132281,
+    "name": "Jhusi",
+    "state_code": "UP"
+  },
+  {
+    "id": 147490,
+    "name": "Jiyanpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132303,
+    "name": "Jyotiba Phule Nagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 132320,
+    "name": "Kabrai",
+    "state_code": "UP"
+  },
+  {
+    "id": 132322,
+    "name": "Kachhwa",
+    "state_code": "UP"
+  },
+  {
+    "id": 132325,
+    "name": "Kadaura",
+    "state_code": "UP"
+  },
+  {
+    "id": 132676,
+    "name": "Kadipur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147491,
+    "name": "Kagarol",
+    "state_code": "UP"
+  },
+  {
+    "id": 132335,
+    "name": "Kaimganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 132339,
+    "name": "Kairana",
+    "state_code": "UP"
+  },
+  {
+    "id": 132679,
+    "name": "Kakori",
+    "state_code": "UP"
+  },
+  {
+    "id": 132342,
+    "name": "Kakrala",
+    "state_code": "UP"
+  },
+  {
+    "id": 132690,
+    "name": "Kalinagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 132683,
+    "name": "Kalpi",
+    "state_code": "UP"
+  },
+  {
+    "id": 147492,
+    "name": "Kalyanpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132361,
+    "name": "Kamalganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 132364,
+    "name": "Kampil",
+    "state_code": "UP"
+  },
+  {
+    "id": 132697,
+    "name": "Kandhla",
+    "state_code": "UP"
+  },
+  {
+    "id": 132378,
+    "name": "Kannauj",
+    "state_code": "UP"
+  },
+  {
+    "id": 132384,
+    "name": "Kanpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132385,
+    "name": "Kanpur Dehat",
+    "state_code": "UP"
+  },
+  {
+    "id": 132711,
+    "name": "Kant",
+    "state_code": "UP"
+  },
+  {
+    "id": 132712,
+    "name": "Kanth",
+    "state_code": "UP"
+  },
+  {
+    "id": 147493,
+    "name": "Kaptanganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 147494,
+    "name": "Kara",
+    "state_code": "UP"
+  },
+  {
+    "id": 132413,
+    "name": "Karari",
+    "state_code": "UP"
+  },
+  {
+    "id": 147495,
+    "name": "Karbigwan",
+    "state_code": "UP"
+  },
+  {
+    "id": 147496,
+    "name": "Karchana",
+    "state_code": "UP"
+  },
+  {
+    "id": 132400,
+    "name": "Karhal",
+    "state_code": "UP"
+  },
+  {
+    "id": 132722,
+    "name": "Kasganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 132426,
+    "name": "Katra",
+    "state_code": "UP"
+  },
+  {
+    "id": 147497,
+    "name": "Kausani",
+    "state_code": "UP"
+  },
+  {
+    "id": 132430,
+    "name": "Kaushambi District",
+    "state_code": "UP"
+  },
+  {
+    "id": 132440,
+    "name": "Kemri",
+    "state_code": "UP"
+  },
+  {
+    "id": 132449,
+    "name": "Khada",
+    "state_code": "UP"
+  },
+  {
+    "id": 132512,
+    "name": "Khaga",
+    "state_code": "UP"
+  },
+  {
+    "id": 147498,
+    "name": "Khailar",
+    "state_code": "UP"
+  },
+  {
+    "id": 132454,
+    "name": "Khair",
+    "state_code": "UP"
+  },
+  {
+    "id": 132455,
+    "name": "Khairabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 132459,
+    "name": "Khalilabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 132514,
+    "name": "Khanpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132473,
+    "name": "Kharela",
+    "state_code": "UP"
+  },
+  {
+    "id": 132475,
+    "name": "Khargupur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132479,
+    "name": "Kharkhauda",
+    "state_code": "UP"
+  },
+  {
+    "id": 132483,
+    "name": "Khatauli",
+    "state_code": "UP"
+  },
+  {
+    "id": 132490,
+    "name": "Khekra",
+    "state_code": "UP"
+  },
+  {
+    "id": 132492,
+    "name": "Kheri",
+    "state_code": "UP"
+  },
+  {
+    "id": 132503,
+    "name": "Khudaganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 132509,
+    "name": "Khurja",
+    "state_code": "UP"
+  },
+  {
+    "id": 132520,
+    "name": "Khutar",
+    "state_code": "UP"
+  },
+  {
+    "id": 132528,
+    "name": "Kirakat",
+    "state_code": "UP"
+  },
+  {
+    "id": 132526,
+    "name": "Kiraoli",
+    "state_code": "UP"
+  },
+  {
+    "id": 132734,
+    "name": "Kiratpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132531,
+    "name": "Kishanpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147499,
+    "name": "Kishanpur baral",
+    "state_code": "UP"
+  },
+  {
+    "id": 132532,
+    "name": "Kishni",
+    "state_code": "UP"
+  },
+  {
+    "id": 132535,
+    "name": "Kithor",
+    "state_code": "UP"
+  },
+  {
+    "id": 132564,
+    "name": "Konch",
+    "state_code": "UP"
+  },
+  {
+    "id": 132575,
+    "name": "Kopaganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 132589,
+    "name": "Kosi",
+    "state_code": "UP"
+  },
+  {
+    "id": 132592,
+    "name": "Kota",
+    "state_code": "UP"
+  },
+  {
+    "id": 132605,
+    "name": "Kotra",
+    "state_code": "UP"
+  },
+  {
+    "id": 147500,
+    "name": "Kuchesar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147501,
+    "name": "Kudarkot",
+    "state_code": "UP"
+  },
+  {
+    "id": 132635,
+    "name": "Kulpahar",
+    "state_code": "UP"
+  },
+  {
+    "id": 132644,
+    "name": "Kunda",
+    "state_code": "UP"
+  },
+  {
+    "id": 132645,
+    "name": "Kundarkhi",
+    "state_code": "UP"
+  },
+  {
+    "id": 147502,
+    "name": "Kundarki",
+    "state_code": "UP"
+  },
+  {
+    "id": 132664,
+    "name": "Kurara",
+    "state_code": "UP"
+  },
+  {
+    "id": 147503,
+    "name": "Kurebharsaidkhanpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132665,
+    "name": "Kushinagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147504,
+    "name": "Kusmara",
+    "state_code": "UP"
+  },
+  {
+    "id": 147505,
+    "name": "Kuthaund",
+    "state_code": "UP"
+  },
+  {
+    "id": 132790,
+    "name": "Laharpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132748,
+    "name": "Lakhimpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132745,
+    "name": "Lakhna",
+    "state_code": "UP"
+  },
+  {
+    "id": 132796,
+    "name": "Lalganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 132755,
+    "name": "Lalitpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147506,
+    "name": "Lambhua",
+    "state_code": "UP"
+  },
+  {
+    "id": 132757,
+    "name": "Lar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147507,
+    "name": "Lawar",
+    "state_code": "UP"
+  },
+  {
+    "id": 132803,
+    "name": "Lawar Khas",
+    "state_code": "UP"
+  },
+  {
+    "id": 132775,
+    "name": "Loni",
+    "state_code": "UP"
+  },
+  {
+    "id": 132782,
+    "name": "Lucknow",
+    "state_code": "UP"
+  },
+  {
+    "id": 132783,
+    "name": "Lucknow District",
+    "state_code": "UP"
+  },
+  {
+    "id": 147508,
+    "name": "Machhali Shahar",
+    "state_code": "UP"
+  },
+  {
+    "id": 132805,
+    "name": "Machhlishahr",
+    "state_code": "UP"
+  },
+  {
+    "id": 133057,
+    "name": "Madhoganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 133058,
+    "name": "Madhogarh",
+    "state_code": "UP"
+  },
+  {
+    "id": 132823,
+    "name": "Maghar",
+    "state_code": "UP"
+  },
+  {
+    "id": 132845,
+    "name": "Mahaban",
+    "state_code": "UP"
+  },
+  {
+    "id": 132826,
+    "name": "Maharajganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 132836,
+    "name": "Mahmudabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 132837,
+    "name": "Mahoba",
+    "state_code": "UP"
+  },
+  {
+    "id": 132839,
+    "name": "Maholi",
+    "state_code": "UP"
+  },
+  {
+    "id": 147509,
+    "name": "Mahrajganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 147510,
+    "name": "Mahrajganj (Raebareli)",
+    "state_code": "UP"
+  },
+  {
+    "id": 132840,
+    "name": "Mahroni",
+    "state_code": "UP"
+  },
+  {
+    "id": 147511,
+    "name": "Mahul",
+    "state_code": "UP"
+  },
+  {
+    "id": 132855,
+    "name": "Mailani",
+    "state_code": "UP"
+  },
+  {
+    "id": 132857,
+    "name": "Mainpuri",
+    "state_code": "UP"
+  },
+  {
+    "id": 147512,
+    "name": "Majhupur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147513,
+    "name": "Makanpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147514,
+    "name": "Malasa",
+    "state_code": "UP"
+  },
+  {
+    "id": 132878,
+    "name": "Malihabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 132899,
+    "name": "Mandawar",
+    "state_code": "UP"
+  },
+  {
+    "id": 132910,
+    "name": "Maniar",
+    "state_code": "UP"
+  },
+  {
+    "id": 133079,
+    "name": "Manikpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132914,
+    "name": "Manjhanpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132917,
+    "name": "Mankapur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133087,
+    "name": "Marahra",
+    "state_code": "UP"
+  },
+  {
+    "id": 132936,
+    "name": "Mariahu",
+    "state_code": "UP"
+  },
+  {
+    "id": 132940,
+    "name": "Mataundh",
+    "state_code": "UP"
+  },
+  {
+    "id": 132941,
+    "name": "Mathura",
+    "state_code": "UP"
+  },
+  {
+    "id": 132944,
+    "name": "Mau",
+    "state_code": "UP"
+  },
+  {
+    "id": 147515,
+    "name": "Mau Aima",
+    "state_code": "UP"
+  },
+  {
+    "id": 132945,
+    "name": "Mau Aimma",
+    "state_code": "UP"
+  },
+  {
+    "id": 132946,
+    "name": "Maudaha",
+    "state_code": "UP"
+  },
+  {
+    "id": 147516,
+    "name": "Maurawan",
+    "state_code": "UP"
+  },
+  {
+    "id": 132951,
+    "name": "Mawana",
+    "state_code": "UP"
+  },
+  {
+    "id": 147517,
+    "name": "Mawar",
+    "state_code": "UP"
+  },
+  {
+    "id": 132958,
+    "name": "Meerut",
+    "state_code": "UP"
+  },
+  {
+    "id": 147518,
+    "name": "Mehdawal",
+    "state_code": "UP"
+  },
+  {
+    "id": 132962,
+    "name": "Mehnagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 132963,
+    "name": "Mehndawal",
+    "state_code": "UP"
+  },
+  {
+    "id": 132974,
+    "name": "Milak",
+    "state_code": "UP"
+  },
+  {
+    "id": 147519,
+    "name": "Milkipur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133096,
+    "name": "Miranpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133097,
+    "name": "Miranpur Katra",
+    "state_code": "UP"
+  },
+  {
+    "id": 133095,
+    "name": "Mirganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 132976,
+    "name": "Mirzapur",
+    "state_code": "UP"
+  },
+  {
+    "id": 132977,
+    "name": "Misrikh",
+    "state_code": "UP"
+  },
+  {
+    "id": 132986,
+    "name": "Mohan",
+    "state_code": "UP"
+  },
+  {
+    "id": 132981,
+    "name": "Mohanpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133001,
+    "name": "Moradabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 133004,
+    "name": "Moth",
+    "state_code": "UP"
+  },
+  {
+    "id": 133007,
+    "name": "Mubarakpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133014,
+    "name": "Mughal Sarai",
+    "state_code": "UP"
+  },
+  {
+    "id": 133016,
+    "name": "Muhammadabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 147520,
+    "name": "Mukteshwar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147521,
+    "name": "Mungra Badshahpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147522,
+    "name": "Munsyari",
+    "state_code": "UP"
+  },
+  {
+    "id": 147523,
+    "name": "Muradabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 133043,
+    "name": "Muradnagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 133038,
+    "name": "Mursan",
+    "state_code": "UP"
+  },
+  {
+    "id": 133048,
+    "name": "Musafir-Khana",
+    "state_code": "UP"
+  },
+  {
+    "id": 147524,
+    "name": "Musafirkhana",
+    "state_code": "UP"
+  },
+  {
+    "id": 133051,
+    "name": "Muzaffarnagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 133109,
+    "name": "Nadigaon",
+    "state_code": "UP"
+  },
+  {
+    "id": 133120,
+    "name": "Nagina",
+    "state_code": "UP"
+  },
+  {
+    "id": 147525,
+    "name": "Nagla",
+    "state_code": "UP"
+  },
+  {
+    "id": 133119,
+    "name": "Nagram",
+    "state_code": "UP"
+  },
+  {
+    "id": 133127,
+    "name": "Najibabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 133129,
+    "name": "Nakur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133139,
+    "name": "Nanauta",
+    "state_code": "UP"
+  },
+  {
+    "id": 133142,
+    "name": "Nandgaon",
+    "state_code": "UP"
+  },
+  {
+    "id": 133270,
+    "name": "Nanpara",
+    "state_code": "UP"
+  },
+  {
+    "id": 133161,
+    "name": "Narauli",
+    "state_code": "UP"
+  },
+  {
+    "id": 133162,
+    "name": "Naraura",
+    "state_code": "UP"
+  },
+  {
+    "id": 147526,
+    "name": "Narora",
+    "state_code": "UP"
+  },
+  {
+    "id": 147527,
+    "name": "Naugama",
+    "state_code": "UP"
+  },
+  {
+    "id": 147528,
+    "name": "Naurangpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133183,
+    "name": "Nautanwa",
+    "state_code": "UP"
+  },
+  {
+    "id": 133191,
+    "name": "Nawabganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 147529,
+    "name": "Nawabganj (Barabanki)",
+    "state_code": "UP"
+  },
+  {
+    "id": 147530,
+    "name": "Nawabganj (Bareilly)",
+    "state_code": "UP"
+  },
+  {
+    "id": 147531,
+    "name": "Newara",
+    "state_code": "UP"
+  },
+  {
+    "id": 133212,
+    "name": "Nichlaul",
+    "state_code": "UP"
+  },
+  {
+    "id": 147532,
+    "name": "Nigoh",
+    "state_code": "UP"
+  },
+  {
+    "id": 133215,
+    "name": "Nihtaur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133225,
+    "name": "Niwari",
+    "state_code": "UP"
+  },
+  {
+    "id": 133228,
+    "name": "Nizamabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 133230,
+    "name": "Noida",
+    "state_code": "UP"
+  },
+  {
+    "id": 133292,
+    "name": "Nurpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133295,
+    "name": "Obra",
+    "state_code": "UP"
+  },
+  {
+    "id": 133302,
+    "name": "Orai",
+    "state_code": "UP"
+  },
+  {
+    "id": 133303,
+    "name": "Oran",
+    "state_code": "UP"
+  },
+  {
+    "id": 133309,
+    "name": "Pachperwa",
+    "state_code": "UP"
+  },
+  {
+    "id": 133316,
+    "name": "Padrauna",
+    "state_code": "UP"
+  },
+  {
+    "id": 133318,
+    "name": "Pahasu",
+    "state_code": "UP"
+  },
+  {
+    "id": 147533,
+    "name": "Paigaon",
+    "state_code": "UP"
+  },
+  {
+    "id": 133531,
+    "name": "Pali",
+    "state_code": "UP"
+  },
+  {
+    "id": 133326,
+    "name": "Palia Kalan",
+    "state_code": "UP"
+  },
+  {
+    "id": 147534,
+    "name": "Paras Rampur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133550,
+    "name": "Parichha",
+    "state_code": "UP"
+  },
+  {
+    "id": 133372,
+    "name": "Parichhatgarh",
+    "state_code": "UP"
+  },
+  {
+    "id": 133365,
+    "name": "Parshadepur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147535,
+    "name": "Pathakpura",
+    "state_code": "UP"
+  },
+  {
+    "id": 133385,
+    "name": "Patiali",
+    "state_code": "UP"
+  },
+  {
+    "id": 133391,
+    "name": "Patti",
+    "state_code": "UP"
+  },
+  {
+    "id": 133398,
+    "name": "Pawayan",
+    "state_code": "UP"
+  },
+  {
+    "id": 147536,
+    "name": "Payagpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133432,
+    "name": "Phalauda",
+    "state_code": "UP"
+  },
+  {
+    "id": 147537,
+    "name": "Phaphamau",
+    "state_code": "UP"
+  },
+  {
+    "id": 133435,
+    "name": "Phaphund",
+    "state_code": "UP"
+  },
+  {
+    "id": 133436,
+    "name": "Phariha",
+    "state_code": "UP"
+  },
+  {
+    "id": 147538,
+    "name": "Pheona",
+    "state_code": "UP"
+  },
+  {
+    "id": 133443,
+    "name": "Phulpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147539,
+    "name": "Pichhaura",
+    "state_code": "UP"
+  },
+  {
+    "id": 133445,
+    "name": "Pihani",
+    "state_code": "UP"
+  },
+  {
+    "id": 133561,
+    "name": "Pilibhit",
+    "state_code": "UP"
+  },
+  {
+    "id": 133447,
+    "name": "Pilkhua",
+    "state_code": "UP"
+  },
+  {
+    "id": 147540,
+    "name": "Pilkhuwa",
+    "state_code": "UP"
+  },
+  {
+    "id": 133452,
+    "name": "Pinahat",
+    "state_code": "UP"
+  },
+  {
+    "id": 133456,
+    "name": "Pipraich",
+    "state_code": "UP"
+  },
+  {
+    "id": 147541,
+    "name": "Pipri",
+    "state_code": "UP"
+  },
+  {
+    "id": 133488,
+    "name": "Pratapgarh",
+    "state_code": "UP"
+  },
+  {
+    "id": 57640,
+    "name": "Prayagraj (Allahabad)",
+    "state_code": "UP"
+  },
+  {
+    "id": 133495,
+    "name": "Pukhrayan",
+    "state_code": "UP"
+  },
+  {
+    "id": 133569,
+    "name": "Puranpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147542,
+    "name": "Purmafi",
+    "state_code": "UP"
+  },
+  {
+    "id": 133514,
+    "name": "Purwa",
+    "state_code": "UP"
+  },
+  {
+    "id": 147543,
+    "name": "Qadirganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 133578,
+    "name": "Rabupura",
+    "state_code": "UP"
+  },
+  {
+    "id": 147544,
+    "name": "Radha Kund",
+    "state_code": "UP"
+  },
+  {
+    "id": 133658,
+    "name": "Radhakund",
+    "state_code": "UP"
+  },
+  {
+    "id": 133580,
+    "name": "Raebareli",
+    "state_code": "UP"
+  },
+  {
+    "id": 133688,
+    "name": "Rajapur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133700,
+    "name": "Ramkola",
+    "state_code": "UP"
+  },
+  {
+    "id": 133704,
+    "name": "Ramnagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 133705,
+    "name": "Rampur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133707,
+    "name": "Rampura",
+    "state_code": "UP"
+  },
+  {
+    "id": 133720,
+    "name": "Ranipur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147545,
+    "name": "Ranipur Barsi",
+    "state_code": "UP"
+  },
+  {
+    "id": 133612,
+    "name": "Rasra",
+    "state_code": "UP"
+  },
+  {
+    "id": 133613,
+    "name": "Rasulabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 133723,
+    "name": "Rath",
+    "state_code": "UP"
+  },
+  {
+    "id": 133728,
+    "name": "Raya",
+    "state_code": "UP"
+  },
+  {
+    "id": 147546,
+    "name": "Rehar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147547,
+    "name": "Renukoot",
+    "state_code": "UP"
+  },
+  {
+    "id": 133628,
+    "name": "Renukut",
+    "state_code": "UP"
+  },
+  {
+    "id": 133629,
+    "name": "Reoti",
+    "state_code": "UP"
+  },
+  {
+    "id": 147548,
+    "name": "Reotipur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133637,
+    "name": "Richha",
+    "state_code": "UP"
+  },
+  {
+    "id": 133641,
+    "name": "Robertsganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 133737,
+    "name": "Rudarpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147549,
+    "name": "Rudauli",
+    "state_code": "UP"
+  },
+  {
+    "id": 133655,
+    "name": "Rura",
+    "state_code": "UP"
+  },
+  {
+    "id": 147550,
+    "name": "Sabalpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147551,
+    "name": "Sachendi",
+    "state_code": "UP"
+  },
+  {
+    "id": 133744,
+    "name": "Sadabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 134059,
+    "name": "Sadat",
+    "state_code": "UP"
+  },
+  {
+    "id": 133747,
+    "name": "Safipur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133753,
+    "name": "Saharanpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133750,
+    "name": "Sahaspur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133751,
+    "name": "Sahaswan",
+    "state_code": "UP"
+  },
+  {
+    "id": 133754,
+    "name": "Sahawar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147552,
+    "name": "Sahibabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 147553,
+    "name": "Sahpau",
+    "state_code": "UP"
+  },
+  {
+    "id": 133755,
+    "name": "Saidpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147554,
+    "name": "Sakhanu",
+    "state_code": "UP"
+  },
+  {
+    "id": 133762,
+    "name": "Sakit",
+    "state_code": "UP"
+  },
+  {
+    "id": 147555,
+    "name": "Salempur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133765,
+    "name": "Salon",
+    "state_code": "UP"
+  },
+  {
+    "id": 133770,
+    "name": "Sambhal",
+    "state_code": "UP"
+  },
+  {
+    "id": 133773,
+    "name": "Samthar",
+    "state_code": "UP"
+  },
+  {
+    "id": 134072,
+    "name": "Sandi",
+    "state_code": "UP"
+  },
+  {
+    "id": 133778,
+    "name": "Sandila",
+    "state_code": "UP"
+  },
+  {
+    "id": 133792,
+    "name": "Sant Kabir Nagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 133793,
+    "name": "Sant Ravi Das Nagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 133813,
+    "name": "Sarai Akil",
+    "state_code": "UP"
+  },
+  {
+    "id": 133799,
+    "name": "Sarai Ekdil",
+    "state_code": "UP"
+  },
+  {
+    "id": 133812,
+    "name": "Sarai Mir",
+    "state_code": "UP"
+  },
+  {
+    "id": 133802,
+    "name": "Sarauli",
+    "state_code": "UP"
+  },
+  {
+    "id": 133803,
+    "name": "Sardhana",
+    "state_code": "UP"
+  },
+  {
+    "id": 133814,
+    "name": "Sarila",
+    "state_code": "UP"
+  },
+  {
+    "id": 147556,
+    "name": "Sarurpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 134080,
+    "name": "Sasni",
+    "state_code": "UP"
+  },
+  {
+    "id": 133821,
+    "name": "Satrikh",
+    "state_code": "UP"
+  },
+  {
+    "id": 133828,
+    "name": "Saurikh",
+    "state_code": "UP"
+  },
+  {
+    "id": 133833,
+    "name": "Sector",
+    "state_code": "UP"
+  },
+  {
+    "id": 133839,
+    "name": "Seohara",
+    "state_code": "UP"
+  },
+  {
+    "id": 133905,
+    "name": "Shahabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 133892,
+    "name": "Shahganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 133894,
+    "name": "Shahi",
+    "state_code": "UP"
+  },
+  {
+    "id": 133895,
+    "name": "Shahjahanpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133901,
+    "name": "Shahpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133913,
+    "name": "Shamli",
+    "state_code": "UP"
+  },
+  {
+    "id": 133855,
+    "name": "Shamsabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 133856,
+    "name": "Shankargarh",
+    "state_code": "UP"
+  },
+  {
+    "id": 133862,
+    "name": "Shergarh",
+    "state_code": "UP"
+  },
+  {
+    "id": 133864,
+    "name": "Sherkot",
+    "state_code": "UP"
+  },
+  {
+    "id": 147557,
+    "name": "Shibnagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 133869,
+    "name": "Shikarpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 147558,
+    "name": "Shikarpur (Bulandshahr)",
+    "state_code": "UP"
+  },
+  {
+    "id": 133867,
+    "name": "Shikohabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 133914,
+    "name": "Shishgarh",
+    "state_code": "UP"
+  },
+  {
+    "id": 147559,
+    "name": "Shivrajpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133885,
+    "name": "Shrawasti",
+    "state_code": "UP"
+  },
+  {
+    "id": 133918,
+    "name": "Siddharthnagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147560,
+    "name": "Siddhaur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133921,
+    "name": "Sidhauli",
+    "state_code": "UP"
+  },
+  {
+    "id": 133923,
+    "name": "Sidhpura",
+    "state_code": "UP"
+  },
+  {
+    "id": 133929,
+    "name": "Sikandarabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 133928,
+    "name": "Sikandarpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133930,
+    "name": "Sikandra",
+    "state_code": "UP"
+  },
+  {
+    "id": 133931,
+    "name": "Sikandra Rao",
+    "state_code": "UP"
+  },
+  {
+    "id": 147561,
+    "name": "Sikandrabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 133969,
+    "name": "Sirathu",
+    "state_code": "UP"
+  },
+  {
+    "id": 133965,
+    "name": "Sirsa",
+    "state_code": "UP"
+  },
+  {
+    "id": 133966,
+    "name": "Sirsaganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 133963,
+    "name": "Sirsi",
+    "state_code": "UP"
+  },
+  {
+    "id": 133971,
+    "name": "Sisauli",
+    "state_code": "UP"
+  },
+  {
+    "id": 133972,
+    "name": "Siswa Bazar",
+    "state_code": "UP"
+  },
+  {
+    "id": 134091,
+    "name": "Sitapur",
+    "state_code": "UP"
+  },
+  {
+    "id": 133992,
+    "name": "Sonbhadra",
+    "state_code": "UP"
+  },
+  {
+    "id": 134005,
+    "name": "Soron",
+    "state_code": "UP"
+  },
+  {
+    "id": 134056,
+    "name": "Suar",
+    "state_code": "UP"
+  },
+  {
+    "id": 134040,
+    "name": "Sultanpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 134053,
+    "name": "Surianwan",
+    "state_code": "UP"
+  },
+  {
+    "id": 134229,
+    "name": "Tajpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 134231,
+    "name": "Talbahat",
+    "state_code": "UP"
+  },
+  {
+    "id": 134233,
+    "name": "Talgram",
+    "state_code": "UP"
+  },
+  {
+    "id": 134235,
+    "name": "Tanda",
+    "state_code": "UP"
+  },
+  {
+    "id": 147562,
+    "name": "Terha",
+    "state_code": "UP"
+  },
+  {
+    "id": 134136,
+    "name": "Thakurdwara",
+    "state_code": "UP"
+  },
+  {
+    "id": 134165,
+    "name": "Thana Bhawan",
+    "state_code": "UP"
+  },
+  {
+    "id": 147563,
+    "name": "Tigri",
+    "state_code": "UP"
+  },
+  {
+    "id": 134170,
+    "name": "Tikaitnagar",
+    "state_code": "UP"
+  },
+  {
+    "id": 134245,
+    "name": "Tikri",
+    "state_code": "UP"
+  },
+  {
+    "id": 134171,
+    "name": "Tilhar",
+    "state_code": "UP"
+  },
+  {
+    "id": 147564,
+    "name": "Tilsahri",
+    "state_code": "UP"
+  },
+  {
+    "id": 134173,
+    "name": "Tindwari",
+    "state_code": "UP"
+  },
+  {
+    "id": 134202,
+    "name": "Titron",
+    "state_code": "UP"
+  },
+  {
+    "id": 147565,
+    "name": "Tori Fatehpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 134210,
+    "name": "Tori-Fatehpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 134218,
+    "name": "Tulsipur",
+    "state_code": "UP"
+  },
+  {
+    "id": 134248,
+    "name": "Tundla",
+    "state_code": "UP"
+  },
+  {
+    "id": 134261,
+    "name": "Ugu",
+    "state_code": "UP"
+  },
+  {
+    "id": 134262,
+    "name": "Ujhani",
+    "state_code": "UP"
+  },
+  {
+    "id": 147566,
+    "name": "Umri",
+    "state_code": "UP"
+  },
+  {
+    "id": 134471,
+    "name": "Un",
+    "state_code": "UP"
+  },
+  {
+    "id": 134285,
+    "name": "Unnao",
+    "state_code": "UP"
+  },
+  {
+    "id": 147567,
+    "name": "Usawan",
+    "state_code": "UP"
+  },
+  {
+    "id": 134294,
+    "name": "Usehat",
+    "state_code": "UP"
+  },
+  {
+    "id": 147568,
+    "name": "Uska",
+    "state_code": "UP"
+  },
+  {
+    "id": 134296,
+    "name": "Utraula",
+    "state_code": "UP"
+  },
+  {
+    "id": 134327,
+    "name": "Varanasi",
+    "state_code": "UP"
+  },
+  {
+    "id": 147569,
+    "name": "Vindhyachal",
+    "state_code": "UP"
+  },
+  {
+    "id": 134376,
+    "name": "Vrindavan",
+    "state_code": "UP"
+  },
+  {
+    "id": 147570,
+    "name": "Walterganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 134401,
+    "name": "Wazirganj",
+    "state_code": "UP"
+  },
+  {
+    "id": 147571,
+    "name": "Yusufpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 134439,
+    "name": "Zafarabad",
+    "state_code": "UP"
+  },
+  {
+    "id": 134441,
+    "name": "Zaidpur",
+    "state_code": "UP"
+  },
+  {
+    "id": 134442,
+    "name": "Zamania",
+    "state_code": "UP"
+  },
+  {
+    "id": 57643,
+    "name": "Almora",
+    "state_code": "UK"
+  },
+  {
+    "id": 57800,
+    "name": "Bageshwar",
+    "state_code": "UK"
+  },
+  {
+    "id": 57879,
+    "name": "Barkot",
+    "state_code": "UK"
+  },
+  {
+    "id": 58153,
+    "name": "Bazpur",
+    "state_code": "UK"
+  },
+  {
+    "id": 58020,
+    "name": "Bhim Tal",
+    "state_code": "UK"
+  },
+  {
+    "id": 57998,
+    "name": "Bhowali",
+    "state_code": "UK"
+  },
+  {
+    "id": 58059,
+    "name": "Birbhaddar",
+    "state_code": "UK"
+  },
+  {
+    "id": 58176,
+    "name": "Chakrata",
+    "state_code": "UK"
+  },
+  {
+    "id": 58182,
+    "name": "Chamoli",
+    "state_code": "UK"
+  },
+  {
+    "id": 58183,
+    "name": "Champawat",
+    "state_code": "UK"
+  },
+  {
+    "id": 131615,
+    "name": "Clement Town",
+    "state_code": "UK"
+  },
+  {
+    "id": 131676,
+    "name": "Dehradun",
+    "state_code": "UK"
+  },
+  {
+    "id": 131702,
+    "name": "Devaprayag",
+    "state_code": "UK"
+  },
+  {
+    "id": 131754,
+    "name": "Dharchula",
+    "state_code": "UK"
+  },
+  {
+    "id": 131784,
+    "name": "Doiwala",
+    "state_code": "UK"
+  },
+  {
+    "id": 131793,
+    "name": "Dugadda",
+    "state_code": "UK"
+  },
+  {
+    "id": 131804,
+    "name": "Dwarahat",
+    "state_code": "UK"
+  },
+  {
+    "id": 131923,
+    "name": "Garhwal",
+    "state_code": "UK"
+  },
+  {
+    "id": 132058,
+    "name": "Haldwani",
+    "state_code": "UK"
+  },
+  {
+    "id": 132069,
+    "name": "Harbatpur",
+    "state_code": "UK"
+  },
+  {
+    "id": 132075,
+    "name": "Haridwar",
+    "state_code": "UK"
+  },
+  {
+    "id": 132247,
+    "name": "Jaspur",
+    "state_code": "UK"
+  },
+  {
+    "id": 132296,
+    "name": "Joshimath",
+    "state_code": "UK"
+  },
+  {
+    "id": 132685,
+    "name": "Kaladhungi",
+    "state_code": "UK"
+  },
+  {
+    "id": 132686,
+    "name": "Kalagarh Project Colony",
+    "state_code": "UK"
+  },
+  {
+    "id": 132418,
+    "name": "Kashipur",
+    "state_code": "UK"
+  },
+  {
+    "id": 132484,
+    "name": "Khatima",
+    "state_code": "UK"
+  },
+  {
+    "id": 132521,
+    "name": "Kichha",
+    "state_code": "UK"
+  },
+  {
+    "id": 132597,
+    "name": "Kotdwara",
+    "state_code": "UK"
+  },
+  {
+    "id": 132749,
+    "name": "Laksar",
+    "state_code": "UK"
+  },
+  {
+    "id": 132756,
+    "name": "Lansdowne",
+    "state_code": "UK"
+  },
+  {
+    "id": 132767,
+    "name": "Lohaghat",
+    "state_code": "UK"
+  },
+  {
+    "id": 132908,
+    "name": "Manglaur",
+    "state_code": "UK"
+  },
+  {
+    "id": 133046,
+    "name": "Mussoorie",
+    "state_code": "UK"
+  },
+  {
+    "id": 133123,
+    "name": "Naini Tal",
+    "state_code": "UK"
+  },
+  {
+    "id": 133166,
+    "name": "Narendranagar",
+    "state_code": "UK"
+  },
+  {
+    "id": 133394,
+    "name": "Pauri",
+    "state_code": "UK"
+  },
+  {
+    "id": 133563,
+    "name": "Pipalkoti",
+    "state_code": "UK"
+  },
+  {
+    "id": 133464,
+    "name": "Pithoragarh",
+    "state_code": "UK"
+  },
+  {
+    "id": 133666,
+    "name": "Raipur",
+    "state_code": "UK"
+  },
+  {
+    "id": 133735,
+    "name": "Raiwala Bara",
+    "state_code": "UK"
+  },
+  {
+    "id": 133703,
+    "name": "Ramnagar",
+    "state_code": "UK"
+  },
+  {
+    "id": 133716,
+    "name": "Ranikhet",
+    "state_code": "UK"
+  },
+  {
+    "id": 133638,
+    "name": "Rishikesh",
+    "state_code": "UK"
+  },
+  {
+    "id": 133650,
+    "name": "Roorkee",
+    "state_code": "UK"
+  },
+  {
+    "id": 133652,
+    "name": "Rudraprayag",
+    "state_code": "UK"
+  },
+  {
+    "id": 133973,
+    "name": "Sitarganj",
+    "state_code": "UK"
+  },
+  {
+    "id": 134027,
+    "name": "Srinagar",
+    "state_code": "UK"
+  },
+  {
+    "id": 134038,
+    "name": "Sultanpur",
+    "state_code": "UK"
+  },
+  {
+    "id": 134110,
+    "name": "Tanakpur",
+    "state_code": "UK"
+  },
+  {
+    "id": 134122,
+    "name": "Tehri",
+    "state_code": "UK"
+  },
+  {
+    "id": 134123,
+    "name": "Tehri-Garhwal",
+    "state_code": "UK"
+  },
+  {
+    "id": 134256,
+    "name": "Udham Singh Nagar",
+    "state_code": "UK"
+  },
+  {
+    "id": 134301,
+    "name": "Uttarkashi",
+    "state_code": "UK"
+  },
+  {
+    "id": 134360,
+    "name": "Vikasnagar",
+    "state_code": "UK"
+  },
+  {
+    "id": 153350,
+    "name": "Adra",
+    "state_code": "WB"
+  },
+  {
+    "id": 141852,
+    "name": "Ahmedpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141853,
+    "name": "Aistala",
+    "state_code": "WB"
+  },
+  {
+    "id": 141854,
+    "name": "Aknapur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141855,
+    "name": "Alipurduar",
+    "state_code": "WB"
+  },
+  {
+    "id": 142112,
+    "name": "Amlagora",
+    "state_code": "WB"
+  },
+  {
+    "id": 141857,
+    "name": "Amta",
+    "state_code": "WB"
+  },
+  {
+    "id": 141858,
+    "name": "Amtala",
+    "state_code": "WB"
+  },
+  {
+    "id": 141859,
+    "name": "Andal",
+    "state_code": "WB"
+  },
+  {
+    "id": 141860,
+    "name": "Arambagh community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 141861,
+    "name": "Asansol",
+    "state_code": "WB"
+  },
+  {
+    "id": 141862,
+    "name": "Ashoknagar Kalyangarh",
+    "state_code": "WB"
+  },
+  {
+    "id": 141863,
+    "name": "Badkulla",
+    "state_code": "WB"
+  },
+  {
+    "id": 141864,
+    "name": "Baduria",
+    "state_code": "WB"
+  },
+  {
+    "id": 141865,
+    "name": "Bagdogra",
+    "state_code": "WB"
+  },
+  {
+    "id": 141866,
+    "name": "Bagnan",
+    "state_code": "WB"
+  },
+  {
+    "id": 141867,
+    "name": "Bagula",
+    "state_code": "WB"
+  },
+  {
+    "id": 141868,
+    "name": "Bahula",
+    "state_code": "WB"
+  },
+  {
+    "id": 141869,
+    "name": "Baidyabati",
+    "state_code": "WB"
+  },
+  {
+    "id": 141870,
+    "name": "Bakreswar",
+    "state_code": "WB"
+  },
+  {
+    "id": 141871,
+    "name": "Balarampur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141903,
+    "name": "Bali Chak",
+    "state_code": "WB"
+  },
+  {
+    "id": 141872,
+    "name": "Bally",
+    "state_code": "WB"
+  },
+  {
+    "id": 141873,
+    "name": "Balurghat",
+    "state_code": "WB"
+  },
+  {
+    "id": 141874,
+    "name": "Bamangola community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 141875,
+    "name": "Baneswar",
+    "state_code": "WB"
+  },
+  {
+    "id": 141876,
+    "name": "Bangaon",
+    "state_code": "WB"
+  },
+  {
+    "id": 141877,
+    "name": "Bankra",
+    "state_code": "WB"
+  },
+  {
+    "id": 141878,
+    "name": "Bankura",
+    "state_code": "WB"
+  },
+  {
+    "id": 141879,
+    "name": "Bansberia",
+    "state_code": "WB"
+  },
+  {
+    "id": 141880,
+    "name": "Bansihari community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 141881,
+    "name": "Barabazar",
+    "state_code": "WB"
+  },
+  {
+    "id": 141882,
+    "name": "Baranagar",
+    "state_code": "WB"
+  },
+  {
+    "id": 141883,
+    "name": "Barasat",
+    "state_code": "WB"
+  },
+  {
+    "id": 141884,
+    "name": "Bardhaman",
+    "state_code": "WB"
+  },
+  {
+    "id": 141885,
+    "name": "Barjora",
+    "state_code": "WB"
+  },
+  {
+    "id": 141886,
+    "name": "Barrackpore",
+    "state_code": "WB"
+  },
+  {
+    "id": 141887,
+    "name": "Baruipur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141888,
+    "name": "Basanti",
+    "state_code": "WB"
+  },
+  {
+    "id": 141889,
+    "name": "Basirhat",
+    "state_code": "WB"
+  },
+  {
+    "id": 141904,
+    "name": "Bawali",
+    "state_code": "WB"
+  },
+  {
+    "id": 141890,
+    "name": "Begampur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141891,
+    "name": "Belda",
+    "state_code": "WB"
+  },
+  {
+    "id": 141892,
+    "name": "Beldanga",
+    "state_code": "WB"
+  },
+  {
+    "id": 141893,
+    "name": "Beliatore",
+    "state_code": "WB"
+  },
+  {
+    "id": 141894,
+    "name": "Berhampore",
+    "state_code": "WB"
+  },
+  {
+    "id": 141895,
+    "name": "Bhadreswar",
+    "state_code": "WB"
+  },
+  {
+    "id": 141896,
+    "name": "Bhandardaha",
+    "state_code": "WB"
+  },
+  {
+    "id": 141897,
+    "name": "Bhatpara",
+    "state_code": "WB"
+  },
+  {
+    "id": 141898,
+    "name": "Birbhum district",
+    "state_code": "WB"
+  },
+  {
+    "id": 141899,
+    "name": "Birpara",
+    "state_code": "WB"
+  },
+  {
+    "id": 141900,
+    "name": "Bishnupur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141901,
+    "name": "Bolpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141902,
+    "name": "Budge Budge",
+    "state_code": "WB"
+  },
+  {
+    "id": 141905,
+    "name": "Canning",
+    "state_code": "WB"
+  },
+  {
+    "id": 141906,
+    "name": "Chakapara",
+    "state_code": "WB"
+  },
+  {
+    "id": 141907,
+    "name": "Chakdaha",
+    "state_code": "WB"
+  },
+  {
+    "id": 141908,
+    "name": "Champadanga",
+    "state_code": "WB"
+  },
+  {
+    "id": 141914,
+    "name": "Champahati",
+    "state_code": "WB"
+  },
+  {
+    "id": 141909,
+    "name": "Champdani",
+    "state_code": "WB"
+  },
+  {
+    "id": 141910,
+    "name": "Chandannagar",
+    "state_code": "WB"
+  },
+  {
+    "id": 141911,
+    "name": "Chandrakona",
+    "state_code": "WB"
+  },
+  {
+    "id": 141912,
+    "name": "Chittaranjan",
+    "state_code": "WB"
+  },
+  {
+    "id": 141913,
+    "name": "Churulia",
+    "state_code": "WB"
+  },
+  {
+    "id": 141915,
+    "name": "Contai",
+    "state_code": "WB"
+  },
+  {
+    "id": 141916,
+    "name": "Cooch Behar",
+    "state_code": "WB"
+  },
+  {
+    "id": 141917,
+    "name": "Cossimbazar",
+    "state_code": "WB"
+  },
+  {
+    "id": 141918,
+    "name": "Dakshin Dinajpur district",
+    "state_code": "WB"
+  },
+  {
+    "id": 141919,
+    "name": "Dalkola",
+    "state_code": "WB"
+  },
+  {
+    "id": 141920,
+    "name": "Dam Dam",
+    "state_code": "WB"
+  },
+  {
+    "id": 141921,
+    "name": "Darjeeling",
+    "state_code": "WB"
+  },
+  {
+    "id": 141922,
+    "name": "Daulatpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141923,
+    "name": "Debagram",
+    "state_code": "WB"
+  },
+  {
+    "id": 141924,
+    "name": "Debipur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141925,
+    "name": "Dhaniakhali community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 141926,
+    "name": "Dhulagari",
+    "state_code": "WB"
+  },
+  {
+    "id": 141927,
+    "name": "Dhulian",
+    "state_code": "WB"
+  },
+  {
+    "id": 141928,
+    "name": "Dhupguri",
+    "state_code": "WB"
+  },
+  {
+    "id": 141929,
+    "name": "Diamond Harbour",
+    "state_code": "WB"
+  },
+  {
+    "id": 141930,
+    "name": "Digha",
+    "state_code": "WB"
+  },
+  {
+    "id": 141931,
+    "name": "Dinhata",
+    "state_code": "WB"
+  },
+  {
+    "id": 141932,
+    "name": "Domjur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141933,
+    "name": "Dubrajpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141934,
+    "name": "Durgapur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141935,
+    "name": "Egra",
+    "state_code": "WB"
+  },
+  {
+    "id": 141936,
+    "name": "Falakata",
+    "state_code": "WB"
+  },
+  {
+    "id": 141937,
+    "name": "Farakka",
+    "state_code": "WB"
+  },
+  {
+    "id": 141938,
+    "name": "Fort Gloster",
+    "state_code": "WB"
+  },
+  {
+    "id": 141939,
+    "name": "Gaighata community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 141940,
+    "name": "Gairkata",
+    "state_code": "WB"
+  },
+  {
+    "id": 141941,
+    "name": "Gangadharpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141942,
+    "name": "Gangarampur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141943,
+    "name": "Garui",
+    "state_code": "WB"
+  },
+  {
+    "id": 141944,
+    "name": "Garulia",
+    "state_code": "WB"
+  },
+  {
+    "id": 141945,
+    "name": "Ghatal",
+    "state_code": "WB"
+  },
+  {
+    "id": 141946,
+    "name": "Giria",
+    "state_code": "WB"
+  },
+  {
+    "id": 141947,
+    "name": "Gobardanga",
+    "state_code": "WB"
+  },
+  {
+    "id": 141948,
+    "name": "Gobindapur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141950,
+    "name": "Gopalpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141949,
+    "name": "Gopinathpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141951,
+    "name": "Gorubathan",
+    "state_code": "WB"
+  },
+  {
+    "id": 141952,
+    "name": "Gosaba",
+    "state_code": "WB"
+  },
+  {
+    "id": 141953,
+    "name": "Gosanimari",
+    "state_code": "WB"
+  },
+  {
+    "id": 141954,
+    "name": "Gurdaha",
+    "state_code": "WB"
+  },
+  {
+    "id": 141955,
+    "name": "Guskhara",
+    "state_code": "WB"
+  },
+  {
+    "id": 141956,
+    "name": "Habra",
+    "state_code": "WB"
+  },
+  {
+    "id": 141957,
+    "name": "Haldia",
+    "state_code": "WB"
+  },
+  {
+    "id": 141958,
+    "name": "Haldibari",
+    "state_code": "WB"
+  },
+  {
+    "id": 141959,
+    "name": "Halisahar",
+    "state_code": "WB"
+  },
+  {
+    "id": 141960,
+    "name": "Harindanga",
+    "state_code": "WB"
+  },
+  {
+    "id": 141961,
+    "name": "Haringhata",
+    "state_code": "WB"
+  },
+  {
+    "id": 141962,
+    "name": "Haripur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141963,
+    "name": "Hasimara",
+    "state_code": "WB"
+  },
+  {
+    "id": 141964,
+    "name": "Hindusthan Cables Town",
+    "state_code": "WB"
+  },
+  {
+    "id": 141965,
+    "name": "Hooghly district",
+    "state_code": "WB"
+  },
+  {
+    "id": 141966,
+    "name": "Howrah",
+    "state_code": "WB"
+  },
+  {
+    "id": 141967,
+    "name": "Ichapur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141968,
+    "name": "Indpur community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 141969,
+    "name": "Ingraj Bazar",
+    "state_code": "WB"
+  },
+  {
+    "id": 141970,
+    "name": "Islampur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141971,
+    "name": "Jafarpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141972,
+    "name": "Jaigaon",
+    "state_code": "WB"
+  },
+  {
+    "id": 141973,
+    "name": "Jalpaiguri",
+    "state_code": "WB"
+  },
+  {
+    "id": 141974,
+    "name": "Jamuria",
+    "state_code": "WB"
+  },
+  {
+    "id": 141975,
+    "name": "Jangipur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141976,
+    "name": "Jaynagar Majilpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141977,
+    "name": "Jejur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141978,
+    "name": "Jhalida",
+    "state_code": "WB"
+  },
+  {
+    "id": 141979,
+    "name": "Jhargram",
+    "state_code": "WB"
+  },
+  {
+    "id": 141980,
+    "name": "Jhilimili",
+    "state_code": "WB"
+  },
+  {
+    "id": 141981,
+    "name": "Kakdwip",
+    "state_code": "WB"
+  },
+  {
+    "id": 141982,
+    "name": "Kalaikunda",
+    "state_code": "WB"
+  },
+  {
+    "id": 141983,
+    "name": "Kaliaganj",
+    "state_code": "WB"
+  },
+  {
+    "id": 141984,
+    "name": "Kalimpong",
+    "state_code": "WB"
+  },
+  {
+    "id": 141985,
+    "name": "Kalna",
+    "state_code": "WB"
+  },
+  {
+    "id": 141986,
+    "name": "Kalyani",
+    "state_code": "WB"
+  },
+  {
+    "id": 141987,
+    "name": "Kamarhati",
+    "state_code": "WB"
+  },
+  {
+    "id": 141988,
+    "name": "Kamarpukur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141989,
+    "name": "Kanchrapara",
+    "state_code": "WB"
+  },
+  {
+    "id": 141990,
+    "name": "Kandi",
+    "state_code": "WB"
+  },
+  {
+    "id": 141991,
+    "name": "Karimpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141992,
+    "name": "Katwa",
+    "state_code": "WB"
+  },
+  {
+    "id": 141993,
+    "name": "Kenda",
+    "state_code": "WB"
+  },
+  {
+    "id": 141994,
+    "name": "Keshabpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141995,
+    "name": "Kharagpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 141996,
+    "name": "Kharar",
+    "state_code": "WB"
+  },
+  {
+    "id": 141997,
+    "name": "Kharba",
+    "state_code": "WB"
+  },
+  {
+    "id": 141998,
+    "name": "Khardaha",
+    "state_code": "WB"
+  },
+  {
+    "id": 141999,
+    "name": "Khatra",
+    "state_code": "WB"
+  },
+  {
+    "id": 142000,
+    "name": "Kirnahar",
+    "state_code": "WB"
+  },
+  {
+    "id": 142001,
+    "name": "Kolkata",
+    "state_code": "WB"
+  },
+  {
+    "id": 142002,
+    "name": "Konnagar",
+    "state_code": "WB"
+  },
+  {
+    "id": 142003,
+    "name": "Krishnanagar",
+    "state_code": "WB"
+  },
+  {
+    "id": 142004,
+    "name": "Krishnapur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142005,
+    "name": "Kshirpai",
+    "state_code": "WB"
+  },
+  {
+    "id": 142006,
+    "name": "Kulpi",
+    "state_code": "WB"
+  },
+  {
+    "id": 142007,
+    "name": "Kultali",
+    "state_code": "WB"
+  },
+  {
+    "id": 142008,
+    "name": "Kulti",
+    "state_code": "WB"
+  },
+  {
+    "id": 142009,
+    "name": "Kurseong",
+    "state_code": "WB"
+  },
+  {
+    "id": 142010,
+    "name": "Lalgarh",
+    "state_code": "WB"
+  },
+  {
+    "id": 142011,
+    "name": "Lalgola",
+    "state_code": "WB"
+  },
+  {
+    "id": 142012,
+    "name": "Loyabad",
+    "state_code": "WB"
+  },
+  {
+    "id": 142013,
+    "name": "Madanpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142014,
+    "name": "Madhyamgram",
+    "state_code": "WB"
+  },
+  {
+    "id": 142015,
+    "name": "Mahiari",
+    "state_code": "WB"
+  },
+  {
+    "id": 142016,
+    "name": "Mahishadal community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 142017,
+    "name": "Mainaguri",
+    "state_code": "WB"
+  },
+  {
+    "id": 142018,
+    "name": "Manikpara",
+    "state_code": "WB"
+  },
+  {
+    "id": 142019,
+    "name": "Masila",
+    "state_code": "WB"
+  },
+  {
+    "id": 142020,
+    "name": "Mathabhanga",
+    "state_code": "WB"
+  },
+  {
+    "id": 142021,
+    "name": "Matiali community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 142022,
+    "name": "Matigara community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 142023,
+    "name": "Medinipur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142024,
+    "name": "Mejia community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 142025,
+    "name": "Memari",
+    "state_code": "WB"
+  },
+  {
+    "id": 142026,
+    "name": "Mirik",
+    "state_code": "WB"
+  },
+  {
+    "id": 142028,
+    "name": "Monoharpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142029,
+    "name": "Muragacha",
+    "state_code": "WB"
+  },
+  {
+    "id": 142030,
+    "name": "Muri",
+    "state_code": "WB"
+  },
+  {
+    "id": 142031,
+    "name": "Murshidabad",
+    "state_code": "WB"
+  },
+  {
+    "id": 142032,
+    "name": "Nabadwip",
+    "state_code": "WB"
+  },
+  {
+    "id": 142033,
+    "name": "Nabagram",
+    "state_code": "WB"
+  },
+  {
+    "id": 142034,
+    "name": "Nadia district",
+    "state_code": "WB"
+  },
+  {
+    "id": 142035,
+    "name": "Nagarukhra",
+    "state_code": "WB"
+  },
+  {
+    "id": 142036,
+    "name": "Nagrakata",
+    "state_code": "WB"
+  },
+  {
+    "id": 142037,
+    "name": "Naihati",
+    "state_code": "WB"
+  },
+  {
+    "id": 142038,
+    "name": "Naksalbari",
+    "state_code": "WB"
+  },
+  {
+    "id": 142039,
+    "name": "Nalhati",
+    "state_code": "WB"
+  },
+  {
+    "id": 142040,
+    "name": "Nalpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142041,
+    "name": "Namkhana community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 142042,
+    "name": "Nandigram",
+    "state_code": "WB"
+  },
+  {
+    "id": 142043,
+    "name": "Nangi",
+    "state_code": "WB"
+  },
+  {
+    "id": 142044,
+    "name": "Nayagram community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 142045,
+    "name": "North 24 Parganas district",
+    "state_code": "WB"
+  },
+  {
+    "id": 142046,
+    "name": "Odlabari",
+    "state_code": "WB"
+  },
+  {
+    "id": 142047,
+    "name": "Paikpara",
+    "state_code": "WB"
+  },
+  {
+    "id": 142048,
+    "name": "Panagarh",
+    "state_code": "WB"
+  },
+  {
+    "id": 142049,
+    "name": "Panchla",
+    "state_code": "WB"
+  },
+  {
+    "id": 142050,
+    "name": "Panchmura",
+    "state_code": "WB"
+  },
+  {
+    "id": 142051,
+    "name": "Pandua",
+    "state_code": "WB"
+  },
+  {
+    "id": 142052,
+    "name": "Panihati",
+    "state_code": "WB"
+  },
+  {
+    "id": 142053,
+    "name": "Panskura",
+    "state_code": "WB"
+  },
+  {
+    "id": 142054,
+    "name": "Parbatipur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142055,
+    "name": "Paschim Medinipur district",
+    "state_code": "WB"
+  },
+  {
+    "id": 142056,
+    "name": "Patiram",
+    "state_code": "WB"
+  },
+  {
+    "id": 142062,
+    "name": "Patrasaer",
+    "state_code": "WB"
+  },
+  {
+    "id": 142057,
+    "name": "Patuli",
+    "state_code": "WB"
+  },
+  {
+    "id": 142058,
+    "name": "Pujali",
+    "state_code": "WB"
+  },
+  {
+    "id": 142059,
+    "name": "Puncha community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 142060,
+    "name": "Purba Medinipur district",
+    "state_code": "WB"
+  },
+  {
+    "id": 142061,
+    "name": "Purulia",
+    "state_code": "WB"
+  },
+  {
+    "id": 142063,
+    "name": "Raghudebbati",
+    "state_code": "WB"
+  },
+  {
+    "id": 142064,
+    "name": "Raghunathpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142065,
+    "name": "Raiganj",
+    "state_code": "WB"
+  },
+  {
+    "id": 142066,
+    "name": "Rajmahal",
+    "state_code": "WB"
+  },
+  {
+    "id": 142067,
+    "name": "Rajnagar community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 142068,
+    "name": "Ramchandrapur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142069,
+    "name": "Ramjibanpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142075,
+    "name": "Ramnagar",
+    "state_code": "WB"
+  },
+  {
+    "id": 142070,
+    "name": "Rampur Hat",
+    "state_code": "WB"
+  },
+  {
+    "id": 142071,
+    "name": "Ranaghat",
+    "state_code": "WB"
+  },
+  {
+    "id": 142072,
+    "name": "Raniganj",
+    "state_code": "WB"
+  },
+  {
+    "id": 142073,
+    "name": "Raypur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142074,
+    "name": "Rishra",
+    "state_code": "WB"
+  },
+  {
+    "id": 142076,
+    "name": "Sahapur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142077,
+    "name": "Sainthia",
+    "state_code": "WB"
+  },
+  {
+    "id": 142078,
+    "name": "Salanpur community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 142079,
+    "name": "Sankarpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142080,
+    "name": "Sankrail",
+    "state_code": "WB"
+  },
+  {
+    "id": 142081,
+    "name": "Santipur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142082,
+    "name": "Santoshpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142083,
+    "name": "Santuri community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 142084,
+    "name": "Sarenga",
+    "state_code": "WB"
+  },
+  {
+    "id": 142085,
+    "name": "Serampore",
+    "state_code": "WB"
+  },
+  {
+    "id": 142086,
+    "name": "Serpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142087,
+    "name": "Shyamnagar West Bengal",
+    "state_code": "WB"
+  },
+  {
+    "id": 142088,
+    "name": "Siliguri",
+    "state_code": "WB"
+  },
+  {
+    "id": 142089,
+    "name": "Singur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142090,
+    "name": "Sodpur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142091,
+    "name": "Solap",
+    "state_code": "WB"
+  },
+  {
+    "id": 142092,
+    "name": "Sonada",
+    "state_code": "WB"
+  },
+  {
+    "id": 142093,
+    "name": "Sonamukhi",
+    "state_code": "WB"
+  },
+  {
+    "id": 142094,
+    "name": "Sonarpur community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 142095,
+    "name": "South 24 Parganas district",
+    "state_code": "WB"
+  },
+  {
+    "id": 142096,
+    "name": "Srikhanda",
+    "state_code": "WB"
+  },
+  {
+    "id": 142097,
+    "name": "Srirampur",
+    "state_code": "WB"
+  },
+  {
+    "id": 142098,
+    "name": "Suri",
+    "state_code": "WB"
+  },
+  {
+    "id": 142099,
+    "name": "Swarupnagar community development block",
+    "state_code": "WB"
+  },
+  {
+    "id": 142100,
+    "name": "Takdah",
+    "state_code": "WB"
+  },
+  {
+    "id": 142101,
+    "name": "Taki",
+    "state_code": "WB"
+  },
+  {
+    "id": 142102,
+    "name": "Tamluk",
+    "state_code": "WB"
+  },
+  {
+    "id": 142103,
+    "name": "Tarakeswar",
+    "state_code": "WB"
+  },
+  {
+    "id": 142104,
+    "name": "Titagarh",
+    "state_code": "WB"
+  },
+  {
+    "id": 142105,
+    "name": "Tufanganj",
+    "state_code": "WB"
+  },
+  {
+    "id": 142106,
+    "name": "Tulin",
+    "state_code": "WB"
+  },
+  {
+    "id": 142107,
+    "name": "Uchalan",
+    "state_code": "WB"
+  },
+  {
+    "id": 142108,
+    "name": "Ula",
+    "state_code": "WB"
+  },
+  {
+    "id": 142109,
+    "name": "Uluberia",
+    "state_code": "WB"
+  },
+  {
+    "id": 142110,
+    "name": "Uttar Dinajpur district",
+    "state_code": "WB"
+  },
+  {
+    "id": 142111,
+    "name": "Uttarpara Kotrung",
+    "state_code": "WB"
+  }
+]

--- a/lib/data/india_states.json
+++ b/lib/data/india_states.json
@@ -1,0 +1,182 @@
+[
+  {
+    "id": 4023,
+    "name": "Andaman and Nicobar Islands",
+    "state_code": "AN"
+  },
+  {
+    "id": 4017,
+    "name": "Andhra Pradesh",
+    "state_code": "AP"
+  },
+  {
+    "id": 4024,
+    "name": "Arunachal Pradesh",
+    "state_code": "AR"
+  },
+  {
+    "id": 4027,
+    "name": "Assam",
+    "state_code": "AS"
+  },
+  {
+    "id": 4037,
+    "name": "Bihar",
+    "state_code": "BR"
+  },
+  {
+    "id": 4031,
+    "name": "Chandigarh",
+    "state_code": "CH"
+  },
+  {
+    "id": 4040,
+    "name": "Chhattisgarh",
+    "state_code": "CT"
+  },
+  {
+    "id": 4033,
+    "name": "Dadra and Nagar Haveli and Daman and Diu",
+    "state_code": "DH"
+  },
+  {
+    "id": 4021,
+    "name": "Delhi",
+    "state_code": "DL"
+  },
+  {
+    "id": 4009,
+    "name": "Goa",
+    "state_code": "GA"
+  },
+  {
+    "id": 4030,
+    "name": "Gujarat",
+    "state_code": "GJ"
+  },
+  {
+    "id": 4007,
+    "name": "Haryana",
+    "state_code": "HR"
+  },
+  {
+    "id": 4020,
+    "name": "Himachal Pradesh",
+    "state_code": "HP"
+  },
+  {
+    "id": 4029,
+    "name": "Jammu and Kashmir",
+    "state_code": "JK"
+  },
+  {
+    "id": 4025,
+    "name": "Jharkhand",
+    "state_code": "JH"
+  },
+  {
+    "id": 4026,
+    "name": "Karnataka",
+    "state_code": "KA"
+  },
+  {
+    "id": 4028,
+    "name": "Kerala",
+    "state_code": "KL"
+  },
+  {
+    "id": 4852,
+    "name": "Ladakh",
+    "state_code": "LA"
+  },
+  {
+    "id": 4019,
+    "name": "Lakshadweep",
+    "state_code": "LD"
+  },
+  {
+    "id": 4039,
+    "name": "Madhya Pradesh",
+    "state_code": "MP"
+  },
+  {
+    "id": 4008,
+    "name": "Maharashtra",
+    "state_code": "MH"
+  },
+  {
+    "id": 4010,
+    "name": "Manipur",
+    "state_code": "MN"
+  },
+  {
+    "id": 4006,
+    "name": "Meghalaya",
+    "state_code": "ML"
+  },
+  {
+    "id": 4036,
+    "name": "Mizoram",
+    "state_code": "MZ"
+  },
+  {
+    "id": 4018,
+    "name": "Nagaland",
+    "state_code": "NL"
+  },
+  {
+    "id": 4013,
+    "name": "Odisha",
+    "state_code": "OR"
+  },
+  {
+    "id": 4011,
+    "name": "Puducherry",
+    "state_code": "PY"
+  },
+  {
+    "id": 4015,
+    "name": "Punjab",
+    "state_code": "PB"
+  },
+  {
+    "id": 4014,
+    "name": "Rajasthan",
+    "state_code": "RJ"
+  },
+  {
+    "id": 4034,
+    "name": "Sikkim",
+    "state_code": "SK"
+  },
+  {
+    "id": 4035,
+    "name": "Tamil Nadu",
+    "state_code": "TN"
+  },
+  {
+    "id": 4012,
+    "name": "Telangana",
+    "state_code": "TG"
+  },
+  {
+    "id": 4038,
+    "name": "Tripura",
+    "state_code": "TR"
+  },
+  {
+    "id": 4022,
+    "name": "Uttar Pradesh",
+    "state_code": "UP"
+  },
+  {
+    "id": 4016,
+    "name": "Uttarakhand",
+    "state_code": "UK"
+  },
+  {
+    "id": 4853,
+    "name": "West Bengal",
+    "state_code": "WB"
+  }
+]

--- a/lib/hooks/useLocations.ts
+++ b/lib/hooks/useLocations.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+
+export interface State {
+  id: number
+  name: string
+  state_code: string
+}
+
+export interface City {
+  id: number
+  name: string
+  state_code: string
+}
+
+export function useStates() {
+  const [states, setStates] = useState<State[]>([])
+
+  useEffect(() => {
+    async function fetchStates() {
+      const { data, error } = await supabase
+        .from('states')
+        .select('id,name,state_code')
+        .order('name')
+      if (!error && data) {
+        setStates(data as State[])
+      }
+    }
+    fetchStates()
+  }, [])
+
+  return states
+}
+
+export function useCities(stateCode: string | null) {
+  const [cities, setCities] = useState<City[]>([])
+
+  useEffect(() => {
+    if (!stateCode) {
+      setCities([])
+      return
+    }
+    async function fetchCities() {
+      const { data, error } = await supabase
+        .from('cities')
+        .select('id,name,state_code')
+        .eq('state_code', stateCode)
+        .order('name')
+      if (!error && data) {
+        setCities(data as City[])
+      }
+    }
+    fetchCities()
+  }, [stateCode])
+
+  return cities
+}

--- a/lib/types/onboarding.ts
+++ b/lib/types/onboarding.ts
@@ -9,6 +9,7 @@ export interface OnboardingData {
   // Personal info
   gender: "Male" | "Female" | "Other" | null
   birthdate: string | null
+  height: string | null
   city: string | null
   state: string | null
   country: string | null

--- a/scripts/create-india-locations.sql
+++ b/scripts/create-india-locations.sql
@@ -1,0 +1,22 @@
+-- Create table for Indian states
+CREATE TABLE IF NOT EXISTS states (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    state_code TEXT NOT NULL
+);
+
+-- Create table for Indian cities
+CREATE TABLE IF NOT EXISTS cities (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    state_code TEXT NOT NULL REFERENCES states(state_code)
+);
+
+-- Example inserts (add remaining via bulk import)
+INSERT INTO states (id, name, state_code) VALUES (4023, 'Andaman and Nicobar Islands', 'AN') ON CONFLICT DO NOTHING;
+INSERT INTO states (id, name, state_code) VALUES (4017, 'Andhra Pradesh', 'AP') ON CONFLICT DO NOTHING;
+-- ... add all states here
+
+-- Example city insert
+INSERT INTO cities (id, name, state_code) VALUES (133436, 'Hyderabad', 'TG') ON CONFLICT DO NOTHING;
+-- Add all cities similarly or use COPY to import from the json files in lib/data


### PR DESCRIPTION
## Summary
- include location datasets and hooks for states/cities
- make stem stage search cities, states and choose mother tongue
- support height field in onboarding and settings
- expand spiritual info options in settings
- increase profile photo upload limit to 10MB
- adjust dashboard for verified users and disable swipe drag
- add SQL script for states and cities tables

## Testing
- `npx next lint` *(fails: Need to install next)*

------
https://chatgpt.com/codex/tasks/task_e_684f3e62346c83228543f2f81d8dca56