### PR TITLE
Implement headerless dashboard and undo swipe

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -202,11 +202,11 @@ export default function DashboardPage() {
       <MobileNav userProfile={profile} />
 
       {/* Main Content */}
-      <main className={`${!isVerified ? "pt-16 pb-32" : "pt-16 pb-32"} min-h-screen flex flex-col`}>
+      <main className={`${isVerified ? "pt-4 pb-32" : "pt-16 pb-32"} min-h-screen flex flex-col`}>
         {isVerified ? (
           // Verified User - Swipe Interface (No Header)
           <div className="flex-1 flex flex-col">
-            <SwipeStack profiles={profiles} onSwipe={handleSwipe} />
+            <SwipeStack profiles={profiles} onSwipe={handleSwipe} headerless={isVerified} />
           </div>
         ) : (
           // Non-verified User - Original Dashboard

--- a/components/dashboard/mobile-nav.tsx
+++ b/components/dashboard/mobile-nav.tsx
@@ -28,6 +28,9 @@ export default function MobileNav({ userProfile }: MobileNavProps) {
   const router = useRouter()
   const pathname = usePathname()
 
+  const isVerified = userProfile?.verification_status === "verified"
+  const showHeader = !(pathname === "/dashboard" && isVerified)
+
   const handleSignOut = async () => {
     await supabase.auth.signOut()
     router.push("/")
@@ -95,6 +98,7 @@ export default function MobileNav({ userProfile }: MobileNavProps) {
   return (
     <>
       {/* Top Header - Minimal */}
+      {showHeader && (
       <header className="fixed top-0 left-0 right-0 z-40 bg-gradient-to-r from-orange-50 to-pink-50 backdrop-blur-md border-b border-orange-100/50">
         <div className="flex items-center justify-between px-4 py-4">
           {/* Logo on left */}
@@ -200,6 +204,7 @@ export default function MobileNav({ userProfile }: MobileNavProps) {
           </div>
         </div>
       </header>
+      )}
 
       {/* Bottom Navigation - Mobile Fixed */}
       <div

--- a/components/dashboard/swipe-card.tsx
+++ b/components/dashboard/swipe-card.tsx
@@ -14,17 +14,19 @@ import {
   Info,
   ChevronLeft,
   ChevronRight,
+  RotateCcw,
 } from "lucide-react"
 import Image from "next/image"
 
 interface SwipeCardProps {
   profile: any
   onSwipe: (direction: "left" | "right" | "superlike", profileId: string) => void
+  onUndo: () => void
   isTop: boolean
   index: number
 }
 
-export default function SwipeCard({ profile, onSwipe, isTop, index }: SwipeCardProps) {
+export default function SwipeCard({ profile, onSwipe, onUndo, isTop, index }: SwipeCardProps) {
   const [isExpanded, setIsExpanded] = useState(false)
   const [currentImageIndex, setCurrentImageIndex] = useState(0)
   const [currentDetailImageIndex, setCurrentDetailImageIndex] = useState(0)
@@ -79,6 +81,13 @@ export default function SwipeCard({ profile, onSwipe, isTop, index }: SwipeCardP
     setAnimatingButton("superlike")
     onSwipe("superlike", profile.id)
     setTimeout(() => setAnimatingButton(null), 500)
+  }
+
+  const handleUndoClick = () => {
+    if (animatingButton) return
+    setAnimatingButton("undo")
+    onUndo()
+    setTimeout(() => setAnimatingButton(null), 300)
   }
 
   const nextImage = () => {
@@ -326,6 +335,22 @@ export default function SwipeCard({ profile, onSwipe, isTop, index }: SwipeCardP
                 transition={{ duration: 0.4 }}
               >
                 <X className="w-6 h-6" />
+              </motion.button>
+
+              {/* Undo Button */}
+              <motion.button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleUndoClick()
+                }}
+                disabled={animatingButton !== null}
+                className="w-12 h-12 bg-white/90 backdrop-blur-sm rounded-full shadow-lg flex items-center justify-center text-yellow-500 hover:bg-white transition-colors disabled:opacity-50"
+                whileHover={{ scale: 1.1 }}
+                whileTap={{ scale: 0.9 }}
+                animate={animatingButton === "undo" ? { scale: [1, 1.2, 1], rotate: [0, 10, -10, 0] } : {}}
+                transition={{ duration: 0.4 }}
+              >
+                <RotateCcw className="w-6 h-6" />
               </motion.button>
             </div>
           </div>
@@ -612,6 +637,22 @@ export default function SwipeCard({ profile, onSwipe, isTop, index }: SwipeCardP
                 transition={{ duration: 0.4 }}
               >
                 <X className="w-7 h-7" />
+              </motion.button>
+
+              {/* Undo Button */}
+              <motion.button
+                onClick={() => {
+                  setIsExpanded(false)
+                  handleUndoClick()
+                }}
+                disabled={animatingButton !== null}
+                className="w-14 h-14 bg-white shadow-xl rounded-full flex items-center justify-center text-yellow-500 hover:bg-yellow-50 transition-colors disabled:opacity-50 border border-gray-200"
+                whileHover={{ scale: 1.1 }}
+                whileTap={{ scale: 0.9 }}
+                animate={animatingButton === "undo" ? { scale: [1, 1.2, 1], rotate: [0, 10, -10, 0] } : {}}
+                transition={{ duration: 0.4 }}
+              >
+                <RotateCcw className="w-7 h-7" />
               </motion.button>
             </div>
           </motion.div>

--- a/components/dashboard/swipe-stack.tsx
+++ b/components/dashboard/swipe-stack.tsx
@@ -3,19 +3,29 @@
 import { useState } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import SwipeCard from "./swipe-card"
-import { Heart, X, Sparkles, Star } from "lucide-react"
+import { Heart, X, Sparkles, Star, RotateCcw } from "lucide-react"
 
 interface SwipeStackProps {
   profiles: any[]
   onSwipe: (direction: "left" | "right" | "superlike", profileId: string) => void
+  headerless?: boolean
 }
 
-export default function SwipeStack({ profiles, onSwipe }: SwipeStackProps) {
+export default function SwipeStack({ profiles, onSwipe, headerless = false }: SwipeStackProps) {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [swipeDirection, setSwipeDirection] = useState<"left" | "right" | "superlike" | null>(null)
   const [isAnimating, setIsAnimating] = useState(false)
+  const [history, setHistory] = useState<number[]>([])
 
   const visibleProfiles = profiles.slice(currentIndex, currentIndex + 3)
+
+  const handleUndo = () => {
+    if (isAnimating || history.length === 0) return
+
+    const lastIndex = history[history.length - 1]
+    setHistory((prev) => prev.slice(0, -1))
+    setCurrentIndex(lastIndex)
+  }
 
   const handleSwipe = (direction: "left" | "right" | "superlike", profileId: string) => {
     if (isAnimating) return
@@ -28,6 +38,7 @@ export default function SwipeStack({ profiles, onSwipe }: SwipeStackProps) {
 
     // Animate the swipe
     setTimeout(() => {
+      setHistory((prev) => [...prev, currentIndex])
       setCurrentIndex((prev) => prev + 1)
       setSwipeDirection(null)
       setIsAnimating(false)
@@ -66,7 +77,7 @@ export default function SwipeStack({ profiles, onSwipe }: SwipeStackProps) {
   return (
     <div className="flex flex-col h-full">
       {/* Card Stack */}
-      <div className="relative px-4 py-4 h-[calc(100vh-120px)]">
+      <div className={`relative px-4 py-4 ${headerless ? "h-[calc(100vh-80px)]" : "h-[calc(100vh-120px)]"}` }>
         <div className="relative w-full max-w-sm mx-auto h-full">
           <AnimatePresence mode="popLayout">
             {visibleProfiles.map((profile, index) => (
@@ -74,6 +85,7 @@ export default function SwipeStack({ profiles, onSwipe }: SwipeStackProps) {
                 key={`${profile.id}-${currentIndex + index}`}
                 profile={profile}
                 onSwipe={handleSwipe}
+                onUndo={handleUndo}
                 isTop={index === 0}
                 index={index}
               />


### PR DESCRIPTION
## Summary
- hide mobile header on dashboard home for verified users
- add undo swipe functionality in swiping stack
- include undo buttons in card and profile view
- adjust layout for headerless state

## Testing
- `pnpm install`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: Failed to collect page data for /api/payments/[action])*

------
https://chatgpt.com/codex/tasks/task_e_684ff7496d208322b50231746a926068