### PR TITLE
Handle nullable item in payment modal

### DIFF
--- a/components/payment/payment-modal.tsx
+++ b/components/payment/payment-modal.tsx
@@ -17,7 +17,7 @@ interface PaymentModalProps {
     description: string
     features?: string[]
     count?: number
-  }
+  } | null
   onSuccess: () => void
 }
 
@@ -30,6 +30,8 @@ declare global {
 export default function PaymentModal({ isOpen, onClose, item, onSuccess }: PaymentModalProps) {
   const [isProcessing, setIsProcessing] = useState(false)
   const [paymentStep, setPaymentStep] = useState<"details" | "processing" | "success">("details")
+
+  if (!item) return null
 
   const loadRazorpayScript = () => {
     return new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- allow `PaymentModalProps.item` to be null
- short circuit rendering when no item is provided

## Testing
- `pnpm lint` *(fails: node_modules missing)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685031b7aaf88322918739c88ad02ea0