### PR TITLE
Fix PaymentModal rendering

### DIFF
--- a/app/dashboard/store/page.tsx
+++ b/app/dashboard/store/page.tsx
@@ -444,12 +444,14 @@ export default function StorePage() {
       </main>
 
       {/* Payment Modal */}
-      <PaymentModal
-        isOpen={paymentModal.isOpen}
-        onClose={closePaymentModal}
-        item={paymentModal.item}
-        onSuccess={handlePaymentSuccess}
-      />
+      {paymentModal.item && (
+        <PaymentModal
+          isOpen={paymentModal.isOpen}
+          onClose={closePaymentModal}
+          item={paymentModal.item}
+          onSuccess={handlePaymentSuccess}
+        />
+      )}
 
       <Toaster position="top-center" />
     </div>


### PR DESCRIPTION
## Summary
- only show `PaymentModal` when a purchase item is selected

## Testing
- `pnpm lint` *(fails: requires ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6850332bc31483228efc67fe80c373e2