### PR TITLE
Fix store page parsing issue

### DIFF
--- a/app/dashboard/store/page.tsx
+++ b/app/dashboard/store/page.tsx
@@ -32,13 +32,13 @@ const superLikePackages = [
   { count: 4, price: 199, popular: false },
   { count: 10, price: 399, popular: true },
   { count: 40, price: 999, popular: false },
-]
+];
 
 const highlightPackages = [
   { count: 4, price: 199, popular: false },
   { count: 10, price: 399, popular: true },
   { count: 40, price: 999, popular: false },
-]
+];
 
 export default function StorePage() {
   const [user, setUser] = useState<SupabaseUser | null>(null)
@@ -136,7 +136,7 @@ export default function StorePage() {
       monthly: { price: 49000, duration: "month" },
       quarterly: { price: 129000, duration: "3 months", savings: "12%" },
     },
-  }
+  };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-orange-50 via-amber-50 to-yellow-50">


### PR DESCRIPTION
## Summary
- add semicolons for array constants
- terminate planPricing object with semicolon

## Testing
- `pnpm build` *(fails: `key_id or oauthToken is mandatory`)*
- `npx tsc --noEmit` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851580f28e08322a94f8e3bde8979fc