### PR TITLE
Ensure auth cookies included in client API requests

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -75,7 +75,7 @@ export default function DashboardPage() {
 
   const fetchProfiles = async () => {
     try {
-      const response = await fetch("/api/profiles/discover")
+      const response = await fetch("/api/profiles/discover", { credentials: "include" })
       if (response.ok) {
         const data = await response.json()
         setProfiles(data.profiles || [])
@@ -87,7 +87,7 @@ export default function DashboardPage() {
 
   const fetchSwipeStats = async () => {
     try {
-      const response = await fetch("/api/swipe/stats")
+      const response = await fetch("/api/swipe/stats", { credentials: "include" })
       if (response.ok) {
         const stats = await response.json()
         setSwipeStats(stats)

--- a/components/dashboard/swipe-stack.tsx
+++ b/components/dashboard/swipe-stack.tsx
@@ -36,7 +36,7 @@ export default function SwipeStack({ profiles: initialProfiles, onSwipe, headerl
 
   const fetchSwipeStats = async () => {
     try {
-      const response = await fetch("/api/swipe/stats")
+      const response = await fetch("/api/swipe/stats", { credentials: "include" })
       if (response.ok) {
         const stats = await response.json()
         setSwipeStats(stats)
@@ -49,7 +49,7 @@ export default function SwipeStack({ profiles: initialProfiles, onSwipe, headerl
   const fetchProfiles = async () => {
     try {
       console.log("Fetching profiles...")
-      const response = await fetch("/api/profiles/discover")
+      const response = await fetch("/api/profiles/discover", { credentials: "include" })
       console.log("Profiles response:", response.status)
       if (response.ok) {
         const data = await response.json()


### PR DESCRIPTION
## Summary
- include `credentials: "include"` in dashboard API fetch calls

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516ad4e6948322a16905e00e4b7649