### PR TITLE
Fix verification status checks

### DIFF
--- a/app/dashboard/matches/page.tsx
+++ b/app/dashboard/matches/page.tsx
@@ -174,7 +174,18 @@ export default function MatchesPage() {
         setProfile(profileData)
 
         // Set matches based on verification status
-        if (profileData?.verification_status === "verified") {
+        const isVerifiedAccount =
+          profileData?.verification_status === "verified" ||
+          [
+            "active",
+            "sparsh",
+            "sangam",
+            "samarpan",
+            "premium",
+            "elite",
+          ].includes(profileData?.account_status ?? "")
+
+        if (isVerifiedAccount) {
           setMatches(mockMatches)
           setLikesReceived(mockLikesReceived)
           setSuperlikesReceived(mockSuperlikesReceived)
@@ -210,7 +221,11 @@ export default function MatchesPage() {
     )
   }
 
-  const isVerified = profile?.verification_status === "verified"
+  const isVerified =
+    profile?.verification_status === "verified" ||
+    ["active", "sparsh", "sangam", "samarpan", "premium", "elite"].includes(
+      profile?.account_status ?? "",
+    )
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-orange-50 via-amber-50 to-yellow-50">

--- a/app/dashboard/messages/page.tsx
+++ b/app/dashboard/messages/page.tsx
@@ -144,7 +144,18 @@ export default function MessagesPage() {
         setProfile(profileData)
 
         // Set conversations based on verification status
-        if (profileData?.verification_status === "verified") {
+        const isVerifiedAccount =
+          profileData?.verification_status === "verified" ||
+          [
+            "active",
+            "sparsh",
+            "sangam",
+            "samarpan",
+            "premium",
+            "elite",
+          ].includes(profileData?.account_status ?? "")
+
+        if (isVerifiedAccount) {
           setConversations(mockConversations)
           setMessages(mockMessages)
         }
@@ -270,7 +281,11 @@ export default function MessagesPage() {
     )
   }
 
-  const isVerified = profile?.verification_status === "verified"
+  const isVerified =
+    profile?.verification_status === "verified" ||
+    ["active", "sparsh", "sangam", "samarpan", "premium", "elite"].includes(
+      profile?.account_status ?? "",
+    )
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-orange-50 via-amber-50 to-yellow-50">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -58,7 +58,18 @@ export default function DashboardPage() {
         console.log("Account status:", profileData?.account_status)
 
         // If verified, fetch profiles and swipe stats
-        if (profileData?.verification_status === "verified" || profileData?.account_status === "active") {
+        const isVerifiedAccount =
+          profileData?.verification_status === "verified" ||
+          [
+            "active",
+            "sparsh",
+            "sangam",
+            "samarpan",
+            "premium",
+            "elite",
+          ].includes(profileData?.account_status ?? "")
+
+        if (isVerifiedAccount) {
           fetchProfiles()
           fetchSwipeStats()
         }
@@ -173,7 +184,9 @@ export default function DashboardPage() {
   const profileCompleteness = calculateProfileCompleteness()
   const isVerified =
     profile?.verification_status === "verified" ||
-    profile?.account_status === "active"
+    ["active", "sparsh", "sangam", "samarpan", "premium", "elite"].includes(
+      profile?.account_status ?? "",
+    )
   console.log("Is verified:", isVerified)
 
   return (

--- a/components/dashboard/mobile-nav.tsx
+++ b/components/dashboard/mobile-nav.tsx
@@ -28,7 +28,11 @@ export default function MobileNav({ userProfile }: MobileNavProps) {
   const router = useRouter()
   const pathname = usePathname()
 
-  const isVerified = userProfile?.verification_status === "verified"
+  const isVerified =
+    userProfile?.verification_status === "verified" ||
+    ["active", "sparsh", "sangam", "samarpan", "premium", "elite"].includes(
+      userProfile?.account_status ?? "",
+    )
   const showHeader = !(pathname === "/dashboard" && isVerified)
 
   const handleSignOut = async () => {


### PR DESCRIPTION
## Summary
- broaden the account status list considered verified in the dashboard
- apply the updated list to matches and messages pages
- update the mobile nav check so verified accounts see the correct header

## Testing
- `pnpm install`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68516abbc110832282b008cfa69f3115