### PR TITLE
Fix admin dashboard auth

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -141,14 +141,7 @@ export default function AdminDashboard() {
   const fetchAdminData = async () => {
     setLoading(true)
     try {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession()
-      const token = session?.access_token
       const response = await fetch("/api/admin/dashboard", {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
         credentials: "include",
       })
 


### PR DESCRIPTION
## Summary
- use cookie-based auth to fetch admin data
- simplify admin page request logic

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f6c16c888322ab32ad5eb5348d8f