### PR TITLE
Fix admin auth session

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,6 +1,9 @@
-import { createClient } from '@supabase/supabase-js'
+import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs'
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
-)
+// Use auth helpers client so the session is stored in cookies that the
+// server-side helpers can read. This is required for API routes to detect
+// the logged in user.
+export const supabase = createBrowserSupabaseClient({
+  supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+  supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
+})

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,9 +1,12 @@
-import { createClient } from "@supabase/supabase-js"
+import { createBrowserSupabaseClient } from "@supabase/auth-helpers-nextjs"
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
-)
+// Mirror the browser client used throughout the app. This ensures the
+// authentication session is persisted in cookies and can be read by server
+// components and API routes.
+export const supabase = createBrowserSupabaseClient({
+  supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+  supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
+})
 
 // Export as default for compatibility
 export default supabase


### PR DESCRIPTION
## Summary
- use `createBrowserSupabaseClient` for client side supabase

## Testing
- `npm run lint` *(fails: Next.js prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6855cb0bce388322b1ebb75d677e816a