### PR TITLE
Fix admin session cookies

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+
+export async function POST(request: NextRequest) {
+  const supabase = createRouteHandlerClient({ cookies })
+  const { event, session } = await request.json()
+
+  if (event === 'SIGNED_IN' && session) {
+    await supabase.auth.setSession(session)
+  }
+  if (event === 'SIGNED_OUT') {
+    await supabase.auth.signOut()
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,6 +1,18 @@
-import { createClient } from '@supabase/supabase-js'
+import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs'
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
-)
+// Use auth helpers client so the session is stored in cookies that the
+// server-side helpers can read. This is required for API routes to detect
+// the logged in user.
+export const supabase = createBrowserSupabaseClient({
+  supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+  supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
+})
+
+supabase.auth.onAuthStateChange((event, session) => {
+  fetch('/api/auth/callback', {
+    method: 'POST',
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    credentials: 'same-origin',
+    body: JSON.stringify({ event, session }),
+  })
+})

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,9 +1,21 @@
-import { createClient } from "@supabase/supabase-js"
+import { createBrowserSupabaseClient } from "@supabase/auth-helpers-nextjs"
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
-)
+// Mirror the browser client used throughout the app. This ensures the
+// authentication session is persisted in cookies and can be read by server
+// components and API routes.
+export const supabase = createBrowserSupabaseClient({
+  supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+  supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
+})
+
+supabase.auth.onAuthStateChange((event, session) => {
+  fetch('/api/auth/callback', {
+    method: 'POST',
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    credentials: 'same-origin',
+    body: JSON.stringify({ event, session }),
+  })
+})
 
 // Export as default for compatibility
 export default supabase


### PR DESCRIPTION
## Summary
- add POST handler at `/api/auth/callback` so auth-helpers can store sessions in cookies
- call the callback on auth state changes from the Supabase clients

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6855cb0bce388322b1ebb75d677e816a