### PR TITLE
Use signed URLs for private images

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -79,7 +79,7 @@ interface UserType {
   verification_status: string
   created_at: string
   updated_at: string
-  user_photos: string[]
+  signedUrls: string[]
   is_active: boolean
   email_verified: boolean
   mobile_verified: boolean
@@ -837,7 +837,7 @@ export default function AdminDashboard() {
                       <div key={user.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
                         <div className="flex items-center gap-3">
                           <Avatar className="h-10 w-10">
-                            <AvatarImage src={user.user_photos?.[0] || "/placeholder.svg"} />
+                            <AvatarImage src={user.signedUrls?.[0] || "/placeholder.svg"} />
                             <AvatarFallback>
                               {user.first_name?.[0] || "U"}
                               {user.last_name?.[0] || "U"}
@@ -968,7 +968,7 @@ export default function AdminDashboard() {
                       >
                         <div className="flex items-center gap-4">
                           <Avatar className="h-12 w-12">
-                            <AvatarImage src={user.user_photos?.[0] || "/placeholder.svg"} />
+                            <AvatarImage src={user.signedUrls?.[0] || "/placeholder.svg"} />
                             <AvatarFallback>
                               {user.first_name?.[0] || "U"}
                               {user.last_name?.[0] || "U"}
@@ -1142,7 +1142,7 @@ export default function AdminDashboard() {
                         <div key={user.id} className="flex items-center justify-between p-4 border rounded-lg">
                           <div className="flex items-center gap-4">
                             <Avatar className="h-16 w-16">
-                              <AvatarImage src={user.user_photos?.[0] || "/placeholder.svg"} />
+                              <AvatarImage src={user.signedUrls?.[0] || "/placeholder.svg"} />
                               <AvatarFallback className="text-lg">
                                 {user.first_name?.[0] || "U"}
                                 {user.last_name?.[0] || "U"}
@@ -1181,10 +1181,10 @@ export default function AdminDashboard() {
                                 <Badge variant="outline">{user.gender || "Not specified"}</Badge>
                                 <Badge variant="outline">{user.education || "Education not set"}</Badge>
                                 <Badge variant="outline">{user.profession || "Profession not set"}</Badge>
-                                {user.user_photos && user.user_photos.length > 0 && (
+                                {user.signedUrls && user.signedUrls.length > 0 && (
                                   <Badge variant="outline" className="text-green-600">
                                     <ImageIcon className="w-3 h-3 mr-1" />
-                                    {user.user_photos.length} photos
+                                    {user.signedUrls.length} photos
                                   </Badge>
                                 )}
                               </div>
@@ -1404,7 +1404,7 @@ export default function AdminDashboard() {
               <div className="flex items-start gap-6 p-6 bg-gradient-to-r from-orange-50 to-pink-50 rounded-lg">
                 <div className="flex flex-col items-center gap-4">
                   <Avatar className="h-32 w-32 border-4 border-white shadow-lg">
-                    <AvatarImage src={selectedUser.user_photos?.[0] || "/placeholder.svg"} />
+                    <AvatarImage src={selectedUser.signedUrls?.[0] || "/placeholder.svg"} />
                     <AvatarFallback className="text-2xl bg-gradient-to-br from-orange-200 to-pink-200">
                       {selectedUser.first_name?.[0] || "U"}
                       {selectedUser.last_name?.[0] || "U"}
@@ -1729,17 +1729,17 @@ export default function AdminDashboard() {
               )}
 
               {/* Photos Gallery */}
-              {selectedUser.user_photos && selectedUser.user_photos.length > 0 && (
+              {selectedUser.signedUrls && selectedUser.signedUrls.length > 0 && (
                 <Card>
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2">
                       <ImageIcon className="h-5 w-5" />
-                      Photo Gallery ({selectedUser.user_photos.length} photos)
+                      Photo Gallery ({selectedUser.signedUrls.length} photos)
                     </CardTitle>
                   </CardHeader>
                   <CardContent>
                     <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-                      {selectedUser.user_photos.map((photo, index) => (
+                      {selectedUser.signedUrls.map((photo, index) => (
                         <div
                           key={index}
                           className="aspect-square rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-shadow"

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,0 +1,51 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { cookies } from "next/headers"
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs"
+import supabaseAdmin from "@/utils/supabaseAdmin"
+import { getSignedUrlsForPhotos } from "@/utils/getSignedUrls"
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabaseAuth = createRouteHandlerClient({ cookies })
+    const {
+      data: { session },
+      error: sessionError,
+    } = await supabaseAuth.auth.getSession()
+
+    if (sessionError || !session?.user) {
+      return NextResponse.json({ error: "Authentication failed" }, { status: 401 })
+    }
+
+    const { data: adminUser, error: adminError } = await supabaseAdmin
+      .from("users")
+      .select("role")
+      .eq("id", session.user.id)
+      .single()
+
+    if (adminError || !adminUser || !["admin", "super_admin"].includes(adminUser.role?.toLowerCase())) {
+      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 })
+    }
+
+    const { data: users, error } = await supabaseAdmin
+      .from("users")
+      .select("id, user_photos, verification_status")
+
+    if (error) {
+      console.error("Users fetch error:", error)
+      return NextResponse.json({ error: "Failed to fetch users" }, { status: 500 })
+    }
+
+    const mapped = await Promise.all(
+      (users || []).map(async (u) => ({
+        id: u.id,
+        verification_status: u.verification_status,
+        signedUrls: await getSignedUrlsForPhotos(u.user_photos || []),
+      }))
+    )
+
+    return NextResponse.json({ users: mapped })
+  } catch (err) {
+    console.error("Admin users error:", err)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/app/api/profiles/discover/route.ts
+++ b/app/api/profiles/discover/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { isDevelopmentMode } from "@/lib/dev-auth"
-import { getSignedUrlsForPhotos, supabaseAdmin } from "@/lib/supabase-storage"
+import supabaseAdmin from "@/utils/supabaseAdmin"
+import { getSignedUrlsForPhotos } from "@/utils/getSignedUrls"
 
 // Mock profiles for development
 const MOCK_PROFILES = [
@@ -117,7 +118,7 @@ export async function GET(request: NextRequest) {
     const mapped = await Promise.all(
       (profiles || []).map(async (p) => ({
         ...p,
-        user_photos: await getSignedUrlsForPhotos(p.user_photos || []),
+        signedUrls: await getSignedUrlsForPhotos(p.user_photos || []),
       }))
     )
 

--- a/components/dashboard/mobile-nav.tsx
+++ b/components/dashboard/mobile-nav.tsx
@@ -93,8 +93,8 @@ export default function MobileNav({ userProfile }: MobileNavProps) {
   ]
 
   const getUserPhoto = () => {
-    if (userProfile?.user_photos && userProfile.user_photos.length > 0) {
-      return userProfile.user_photos[0]
+    if (userProfile?.signedUrls && userProfile.signedUrls.length > 0) {
+      return userProfile.signedUrls[0]
     }
     return "/placeholder-user.jpg"
   }

--- a/components/dashboard/swipe-card.tsx
+++ b/components/dashboard/swipe-card.tsx
@@ -112,26 +112,26 @@ export default function SwipeCard({ profile, onSwipe, onUndo, showUndo = false, 
   }
 
   const nextImage = () => {
-    if (profile.user_photos && profile.user_photos.length > 1) {
-      setCurrentImageIndex((prev) => (prev + 1) % profile.user_photos.length)
+    if (profile.signedUrls && profile.signedUrls.length > 1) {
+      setCurrentImageIndex((prev) => (prev + 1) % profile.signedUrls.length)
     }
   }
 
   const prevImage = () => {
-    if (profile.user_photos && profile.user_photos.length > 1) {
-      setCurrentImageIndex((prev) => (prev - 1 + profile.user_photos.length) % profile.user_photos.length)
+    if (profile.signedUrls && profile.signedUrls.length > 1) {
+      setCurrentImageIndex((prev) => (prev - 1 + profile.signedUrls.length) % profile.signedUrls.length)
     }
   }
 
   const nextDetailImage = () => {
-    if (profile.user_photos && profile.user_photos.length > 1) {
-      setCurrentDetailImageIndex((prev) => (prev + 1) % profile.user_photos.length)
+    if (profile.signedUrls && profile.signedUrls.length > 1) {
+      setCurrentDetailImageIndex((prev) => (prev + 1) % profile.signedUrls.length)
     }
   }
 
   const prevDetailImage = () => {
-    if (profile.user_photos && profile.user_photos.length > 1) {
-      setCurrentDetailImageIndex((prev) => (prev - 1 + profile.user_photos.length) % profile.user_photos.length)
+    if (profile.signedUrls && profile.signedUrls.length > 1) {
+      setCurrentDetailImageIndex((prev) => (prev - 1 + profile.signedUrls.length) % profile.signedUrls.length)
     }
   }
 
@@ -153,15 +153,15 @@ export default function SwipeCard({ profile, onSwipe, onUndo, showUndo = false, 
   }
 
   const getCurrentImage = () => {
-    if (profile.user_photos && profile.user_photos.length > 0) {
-      return getOptimizedImageUrl(profile.user_photos[currentImageIndex], 400, 600)
+    if (profile.signedUrls && profile.signedUrls.length > 0) {
+      return getOptimizedImageUrl(profile.signedUrls[currentImageIndex], 400, 600)
     }
     return "/placeholder.svg"
   }
 
   const getCurrentDetailImage = () => {
-    if (profile.user_photos && profile.user_photos.length > 0) {
-      return getOptimizedImageUrl(profile.user_photos[currentDetailImageIndex], 800, 1200)
+    if (profile.signedUrls && profile.signedUrls.length > 0) {
+      return getOptimizedImageUrl(profile.signedUrls[currentDetailImageIndex], 800, 1200)
     }
     return "/placeholder.svg"
   }
@@ -250,7 +250,7 @@ export default function SwipeCard({ profile, onSwipe, onUndo, showUndo = false, 
             </motion.button>
 
             {/* Image Navigation */}
-            {profile.user_photos && profile.user_photos.length > 1 && (
+            {profile.signedUrls && profile.signedUrls.length > 1 && (
               <>
                 <button
                   onClick={(e) => {
@@ -273,7 +273,7 @@ export default function SwipeCard({ profile, onSwipe, onUndo, showUndo = false, 
 
                 {/* Image Indicators */}
                 <div className="absolute top-4 left-1/2 transform -translate-x-1/2 flex gap-2 z-10">
-                  {profile.user_photos.map((_: any, idx: number) => (
+                  {profile.signedUrls.map((_: any, idx: number) => (
                     <div
                       key={idx}
                       className={`w-2 h-2 rounded-full transition-colors ${
@@ -530,7 +530,7 @@ export default function SwipeCard({ profile, onSwipe, onUndo, showUndo = false, 
 
             <div className="pb-32">
               {/* Optimized Swipeable Photo Gallery */}
-              {profile.user_photos && profile.user_photos.length > 0 && (
+              {profile.signedUrls && profile.signedUrls.length > 0 && (
                 <div
                   className="relative h-[50vh] bg-gray-100 overflow-hidden"
                   onTouchStart={handleTouchStart}
@@ -542,7 +542,7 @@ export default function SwipeCard({ profile, onSwipe, onUndo, showUndo = false, 
                       transform: `translateX(-${currentDetailImageIndex * 100}%)`,
                     }}
                   >
-                    {profile.user_photos.map((photo: string, idx: number) => (
+                    {profile.signedUrls.map((photo: string, idx: number) => (
                       <div key={idx} className="w-full h-full relative flex-shrink-0">
                         <Image
                           src={photo || "/placeholder.svg"}
@@ -569,13 +569,13 @@ export default function SwipeCard({ profile, onSwipe, onUndo, showUndo = false, 
                     />
                     <button
                       onClick={nextDetailImage}
-                      disabled={currentDetailImageIndex === profile.user_photos.length - 1}
+                      disabled={currentDetailImageIndex === profile.signedUrls.length - 1}
                       className="flex-1 opacity-0 disabled:cursor-not-allowed"
                     />
                   </div>
 
                   {/* Better Photo Navigation Arrows */}
-                  {profile.user_photos.length > 1 && (
+                  {profile.signedUrls.length > 1 && (
                     <>
                       <motion.button
                         onClick={prevDetailImage}
@@ -588,7 +588,7 @@ export default function SwipeCard({ profile, onSwipe, onUndo, showUndo = false, 
                       </motion.button>
                       <motion.button
                         onClick={nextDetailImage}
-                        disabled={currentDetailImageIndex === profile.user_photos.length - 1}
+                        disabled={currentDetailImageIndex === profile.signedUrls.length - 1}
                         className="absolute right-4 top-1/2 transform -translate-y-1/2 w-14 h-14 bg-white/90 backdrop-blur-sm rounded-full flex items-center justify-center text-gray-700 hover:bg-white shadow-lg transition-all duration-200 disabled:opacity-30 disabled:cursor-not-allowed z-20"
                         whileHover={{ scale: 1.1 }}
                         whileTap={{ scale: 0.9 }}
@@ -600,7 +600,7 @@ export default function SwipeCard({ profile, onSwipe, onUndo, showUndo = false, 
 
                   {/* Photo Navigation Dots */}
                   <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 flex gap-3 z-20">
-                    {profile.user_photos.map((_: any, idx: number) => (
+                    {profile.signedUrls.map((_: any, idx: number) => (
                       <motion.button
                         key={idx}
                         onClick={() => setCurrentDetailImageIndex(idx)}

--- a/components/dashboard/welcome-section.tsx
+++ b/components/dashboard/welcome-section.tsx
@@ -25,8 +25,8 @@ export default function WelcomeSection({ profile }: WelcomeSectionProps) {
   }
 
   const getMainProfileImage = () => {
-    if (profile?.user_photos && profile.user_photos.length > 0) {
-      return profile.user_photos[0]
+    if (profile?.signedUrls && profile.signedUrls.length > 0) {
+      return profile.signedUrls[0]
     }
     return null
   }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,12 @@ const nextConfig = {
       },
       {
         protocol: 'https',
+        hostname: '*.supabase.co',
+        port: '',
+        pathname: '/storage/v1/object/sign/**',
+      },
+      {
+        protocol: 'https',
         hostname: 'via.placeholder.com',
       }
     ],

--- a/utils/getSignedUrls.ts
+++ b/utils/getSignedUrls.ts
@@ -1,0 +1,18 @@
+import supabaseAdmin from "./supabaseAdmin"
+
+export async function getSignedUrlsForPhotos(photoPaths: string[]): Promise<string[]> {
+  const urls: string[] = []
+  for (const path of photoPaths) {
+    const { data, error } = await supabaseAdmin.storage
+      .from("user-photos")
+      .createSignedUrl(path, 60)
+
+    if (error || !data?.signedUrl) {
+      console.error("Failed to create signed URL for", path, error)
+      continue
+    }
+
+    urls.push(data.signedUrl)
+  }
+  return urls
+}

--- a/utils/supabaseAdmin.ts
+++ b/utils/supabaseAdmin.ts
@@ -1,0 +1,11 @@
+import { createClient } from "@supabase/supabase-js"
+
+const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  {
+    auth: { persistSession: false },
+  },
+)
+
+export default supabaseAdmin


### PR DESCRIPTION
## Summary
- create server-side supabase admin client
- helper to generate signed URLs for storage paths
- expose admin users API returning signed image URLs
- use signed URLs in profiles discovery and admin dashboard APIs
- display signed URLs in dashboard and admin UI
- allow signed URLs through Next.js remote patterns

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c378fae8883229d5fc5ae6eada022